### PR TITLE
Add debian copyright analysis script

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,4 +16,4 @@ jobs:
           image_name: ubuntu-18.04
           python_versions: ['3.6']
           test_suites:
-              all: tmp/bin/pytest -n 2 -vvs
+              all: tmp/bin/pytest -n 2 -vvs tests/

--- a/etc/debian_license_detection/rules_deb_copy_test.ipynb
+++ b/etc/debian_license_detection/rules_deb_copy_test.ipynb
@@ -1,0 +1,342 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "57a698d9-43ca-4c6c-a6ab-72a0079a33af",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import io\n",
+    "from os import path\n",
+    "from os import walk"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "ff215caf-b917-41cf-9ed7-fd7e54756aeb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from packagedcode.debian_copyright import parse_copyright_file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "49476d28-c983-447c-a98e-e66d2f6a52a9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from scancode_analyzer.license_analyzer import LicenseDetectionIssue\n",
+    "from scancode_analyzer.summary import SummaryLicenseIssues\n",
+    "\n",
+    "from scancode_analyzer.analyzer_plugin import from_license_match_object\n",
+    "from scancode_analyzer.analyzer_plugin import ScancodeDataChangedError"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "0af20176-27eb-40df-a6f3-a57b26f10fa2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def relative_walk(dir_path):\n",
+    "    \"\"\"\n",
+    "    Walk path and yield files paths relative to dir_path.\n",
+    "    \"\"\"\n",
+    "    for base_dir, _dirs, files in walk(dir_path):\n",
+    "        for file_name in files:\n",
+    "            if file_name.endswith('.yml'):\n",
+    "                continue\n",
+    "            file_path = path.join(base_dir, file_name)\n",
+    "            file_path = file_path.replace(dir_path, '', 1)\n",
+    "            file_path = file_path.strip(path.sep)\n",
+    "            yield file_path\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "8bc446e5-8e5a-4512-9486-da62f406c304",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_copyright_files(test_dir_loc):\n",
+    "    copyright_files = []\n",
+    "    \n",
+    "    for test_file in relative_walk(test_dir_loc):\n",
+    "        test_loc = path.join(test_dir_loc, test_file)\n",
+    "        if test_loc.endswith(\"copyright\"):\n",
+    "            copyright_files.append(test_loc)\n",
+    "        \n",
+    "    return copyright_files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "fb5e04f4-c0b2-4b45-9db0-961377522374",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_dir_loc = \"path/to/scancode-toolkit/tests/packagedcode/data/debian/copyright/debian-slim-2021-04-07/\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "6b689a5e-089d-4384-84b1-c9bf212a73b9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "copyright_files = get_copyright_files(test_dir_loc)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "acec9ded-7d3c-4b0b-b93b-08bc3f7bb286",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "85"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(copyright_files)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "eb34b5e6-afb9-41cc-9a96-036adcf92582",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "structued_license_issues = []\n",
+    "unstructued_license_issues = []\n",
+    "count_files_with_issues = 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "800e3cb6-d379-401c-bce5-123c1457c86b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/ayan/Desktop/nexB/main_repos/scancode-analyzer/tmp/lib/python3.8/site-packages/cluecode/copyrights.py:3163: FutureWarning: Possible set difference at position 3\n",
+      "  remove_tags = re.compile(\n",
+      "/home/ayan/Desktop/nexB/main_repos/scancode-analyzer/tmp/lib/python3.8/site-packages/nltk/tag/sequential.py:540: FutureWarning: Possible nested set at position 7\n",
+      "  self._regexps = [(re.compile(regexp), tag,) for regexp, tag in regexps]\n"
+     ]
+    }
+   ],
+   "source": [
+    "for copyright_file in copyright_files:\n",
+    "    dc = parse_copyright_file(copyright_file)\n",
+    "    license_issues = []\n",
+    "\n",
+    "    # Unstructured Files\n",
+    "    if hasattr(dc, \"license_matches\"):\n",
+    "        license_matches = dc.license_matches\n",
+    "        license_matches_in_format = from_license_match_object(license_matches)\n",
+    "\n",
+    "        issues = list(LicenseDetectionIssue.from_license_matches(\n",
+    "            license_matches=license_matches_in_format,\n",
+    "            is_license_text=False,\n",
+    "            is_legal=False,\n",
+    "            path=copyright_file,\n",
+    "        ))\n",
+    "        if issues:\n",
+    "            count_files_with_issues+=1\n",
+    "            unstructued_license_issues.extend(issues)\n",
+    "    \n",
+    "    #Structured Files\n",
+    "    elif hasattr(dc, \"license_detections\"):\n",
+    "        for license_detection in dc.license_detections:\n",
+    "            \n",
+    "            if not license_detection.license_matches:\n",
+    "                continue\n",
+    "                \n",
+    "            license_matches = license_detection.license_matches\n",
+    "            license_matches_in_format = from_license_match_object(license_matches)\n",
+    "            \n",
+    "            issues = list(LicenseDetectionIssue.from_license_matches(\n",
+    "                license_matches=license_matches_in_format,\n",
+    "                is_license_text=False,\n",
+    "                is_legal=False,\n",
+    "                path=copyright_file,\n",
+    "            ))\n",
+    "            if issues:\n",
+    "                count_files_with_issues+=1\n",
+    "                structued_license_issues.extend(issues)\n",
+    "    \n",
+    "    else:\n",
+    "        raise Exception"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "1895a52f-657d-4436-b5c6-9d2b4422d8d9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "81"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(structued_license_issues)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "86318e3c-64c3-4d65-b350-1d5334e0eb64",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "summary_structured_license = SummaryLicenseIssues.summarize(\n",
+    "    license_issues = structued_license_issues,\n",
+    "    count_has_license = len(copyright_files),\n",
+    "    count_files_with_issues = count_files_with_issues,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "2fc59a6b-9a4c-472e-b6b5-55a8231bdcd7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "133"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(unstructued_license_issues)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "de7d0b05-2bf2-4bff-a165-100a45f1574d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "summary_unstructured_license = SummaryLicenseIssues.summarize(\n",
+    "    license_issues = unstructued_license_issues,\n",
+    "    count_has_license = len(copyright_files),\n",
+    "    count_files_with_issues = count_files_with_issues,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "ebb38498-232e-4168-93f4-9cde93e8823c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "\n",
+    "\n",
+    "def load_json(path):\n",
+    "    with open(path, 'r') as file_handler:\n",
+    "        data = json.load(file_handler)\n",
+    "    return data\n",
+    "\n",
+    "\n",
+    "def write_json(data, path):\n",
+    "    with open(path, 'w') as file_handler:\n",
+    "        json.dump(data, file_handler, indent=2)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "5642a729-6db2-4174-96b6-07b3a73cedb7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results_json_structured_path = \"path/to/structured_debian_result_summary.json\"\n",
+    "results_json_unstructured_path = \"path/to/unstructured_debian_result_summary.json\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "54c8a396-5a92-46c1-a141-0e2ee0c9830b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "write_json(summary_structured_license.to_dict(), results_json_structured_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "75955bc3-0948-4384-ad53-b4477a30677b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "write_json(summary_unstructured_license.to_dict(), results_json_unstructured_path)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/scancode_analyzer/summary.py
+++ b/src/scancode_analyzer/summary.py
@@ -205,7 +205,7 @@ class UniqueIssue:
             unique_issue_category_counts.items(), start=1,
         ):
             file_regions = (
-                issue.file_regions.pop()
+                issue.file_regions[0]
                 for issue in license_issues
                 if unique_issue_identifier in [issue.identifier, issue.identifier_for_unknown_intro]
             )

--- a/tests/data/analyzer-plugins/results_analyzer_expected.json
+++ b/tests/data/analyzer-plugins/results_analyzer_expected.json
@@ -20,6 +20,126 @@
       }
     }
   ],
+  "license_detection_issues_summary": {
+    "statistics": {
+      "total_files_with_license": 3,
+      "total_files_with_license_detection_issues": 2,
+      "total_unique_license_detection_issues": 2,
+      "issue_category_counts": {
+        "near-perfect-match-coverage": 2
+      },
+      "issue_classification_id_counts": {
+        "notice-and-or-with-notice": 1,
+        "notice-single-key-notice": 1
+      },
+      "analysis_confidence_counts": {
+        "high": 2
+      },
+      "license_info_type_counts": {
+        "license_notice": 2
+      }
+    },
+    "unique_license_detection_issues": [
+      {
+        "unique_identifier": 1,
+        "license_detection_issue": {
+          "issue_category": "near-perfect-match-coverage",
+          "issue_description": "The license detection is conclusive with a medium confidence because because most, but not all of the rule text is matched.",
+          "issue_type": {
+            "classification_id": "notice-and-or-with-notice",
+            "classification_description": "A notice with a complex license expression (i.e. exceptions, choices or combinations).",
+            "analysis_confidence": "high",
+            "is_license_text": false,
+            "is_license_notice": true,
+            "is_license_tag": false,
+            "is_license_reference": false,
+            "is_license_intro": false,
+            "is_suggested_matched_text_complete": true
+          },
+          "suggested_license": {
+            "license_expression": "lgpl-2.0-plus WITH libtool-exception-2.0",
+            "matched_text": "GNU Libltdl is free software; you can redistribute it and/or\nmodify it under the terms of the GNU Lesser General Public\nLicense as published by the Free Software Foundation; either\nversion 2 of the License, or (at your option) any later version.\n\nAs a special exception to the GNU Lesser General Public License,\nif you distribute this file as part of a program or library that\nis built using GNU Libtool, you may include this file under the\nsame distribution terms that you use for the rest of that program.\n\nGNU Libltdl is distributed in the hope that it will be useful,\nbut WITHOUT ANY WARRANTY; without even the implied warranty of\nMERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\nGNU Lesser General Public License for more details.\n\nYou should have received a copy of the GNU Lesser General Public\nLicense along with GNU Libltdl; see the file COPYING.LIB.  If not, a\ncopy can be downloaded from  http://www.gnu.org/licenses/lgpl.html,\nor obtained by writing to the Free Software Foundation, Inc.,\n51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA."
+          },
+          "original_licenses": [
+            {
+              "license_expression": "lgpl-2.0-plus WITH libtool-exception-2.0",
+              "score": 95.84,
+              "start_line": 9,
+              "end_line": 28,
+              "rule_identifier": "lgpl-2.0-plus_with_libtool-exception-2.0_2.RULE",
+              "is_license_text": false,
+              "is_license_notice": true,
+              "is_license_reference": false,
+              "is_license_tag": false,
+              "is_license_intro": false,
+              "matcher": "3-seq",
+              "matched_length": 182,
+              "rule_length": 188,
+              "match_coverage": 96.81,
+              "rule_relevance": 99,
+              "matched_text": "GNU Libltdl is free software; you can redistribute it and/or\nmodify it under the terms of the GNU Lesser General Public\nLicense as published by the Free Software Foundation; either\nversion 2 of the License, or (at your option) any later version.\n\nAs a special exception to the GNU Lesser General Public License,\nif you distribute this file as part of a program or library that\nis built using GNU Libtool, you may include this file under the\nsame distribution terms that you use for the rest of that program.\n\nGNU Libltdl is distributed in the hope that it will be useful,\nbut WITHOUT ANY WARRANTY; without even the implied warranty of\nMERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\nGNU Lesser General Public License for more details.\n\nYou should have received a copy of the GNU Lesser General Public\nLicense along with GNU Libltdl; see the file COPYING.LIB.  If not, a\ncopy can be downloaded from  http://www.gnu.org/licenses/lgpl.html,\nor obtained by writing to the Free Software Foundation, Inc.,\n51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA."
+            }
+          ]
+        },
+        "files": [
+          {
+            "path": "scan-files/1912-libtool-2.2.10-argz.c",
+            "start_line": 9,
+            "end_line": 28
+          }
+        ]
+      },
+      {
+        "unique_identifier": 2,
+        "license_detection_issue": {
+          "issue_category": "near-perfect-match-coverage",
+          "issue_description": "The license detection is conclusive with a medium confidence because because most, but not all of the rule text is matched.",
+          "issue_type": {
+            "classification_id": "notice-single-key-notice",
+            "classification_description": "A notice with a single license.",
+            "analysis_confidence": "high",
+            "is_license_text": false,
+            "is_license_notice": true,
+            "is_license_tag": false,
+            "is_license_reference": false,
+            "is_license_intro": false,
+            "is_suggested_matched_text_complete": true
+          },
+          "suggested_license": {
+            "license_expression": "gpl-3.0-plus",
+            "matched_text": " *  AutoOpts is a copyrighted work.  This source file is not encumbered\n *  by AutoOpts licensing, but is provided under the licensing terms chosen\n *  by the genshellopt author or copyright holder.  AutoOpts is\n *  licensed under the terms of the LGPL.  The redistributable library\n *  (``libopts'') is licensed under the terms of either the LGPL or, at the\n *  users discretion, the BSD license.  See the AutoOpts and/or libopts sources\n *  for details.\n *\n * This source file is copyrighted and licensed under the following terms:\n *\n * genshellopt copyright (c) 1999-2009 Bruce Korb - all rights reserved\n *\n * genshellopt is free software: you can redistribute it and/or modify it\n * under the terms of the GNU General Public License as published by the\n * Free Software Foundation, either version 3 of the License, or\n * (at your option) any later version.\n * \n * genshellopt is distributed in the hope that it will be useful, but\n * WITHOUT ANY WARRANTY; without even the implied warranty of\n * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.\n * See the GNU General Public License for more details.\n * \n * You should have received a copy of the GNU General Public License along\n * with this program.  If not, see <http://www.gnu.org/licenses/>."
+          },
+          "original_licenses": [
+            {
+              "license_expression": "gpl-3.0-plus",
+              "score": 95.7,
+              "start_line": 11,
+              "end_line": 34,
+              "rule_identifier": "gpl-3.0-plus_209.RULE",
+              "is_license_text": false,
+              "is_license_notice": true,
+              "is_license_reference": false,
+              "is_license_tag": false,
+              "is_license_intro": false,
+              "matcher": "3-seq",
+              "matched_length": 178,
+              "rule_length": 186,
+              "match_coverage": 95.7,
+              "rule_relevance": 100,
+              "matched_text": " *  AutoOpts is a copyrighted work.  This source file is not encumbered\n *  by AutoOpts licensing, but is provided under the licensing terms chosen\n *  by the genshellopt author or copyright holder.  AutoOpts is\n *  licensed under the terms of the LGPL.  The redistributable library\n *  (``libopts'') is licensed under the terms of either the LGPL or, at the\n *  users discretion, the BSD license.  See the AutoOpts and/or libopts sources\n *  for details.\n *\n * This source file is copyrighted and licensed under the following terms:\n *\n * genshellopt copyright (c) 1999-2009 Bruce Korb - all rights reserved\n *\n * genshellopt is free software: you can redistribute it and/or modify it\n * under the terms of the GNU General Public License as published by the\n * Free Software Foundation, either version 3 of the License, or\n * (at your option) any later version.\n * \n * genshellopt is distributed in the hope that it will be useful, but\n * WITHOUT ANY WARRANTY; without even the implied warranty of\n * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.\n * See the GNU General Public License for more details.\n * \n * You should have received a copy of the GNU General Public License along\n * with this program.  If not, see <http://www.gnu.org/licenses/>."
+            }
+          ]
+        },
+        "files": [
+          {
+            "path": "scan-files/genshell.c",
+            "start_line": 11,
+            "end_line": 34
+          }
+        ]
+      }
+    ]
+  },
   "files": [
     {
       "path": "scan-files",
@@ -28,7 +148,6 @@
       "base_name": "scan-files",
       "extension": "",
       "size": 0,
-      "date": null,
       "sha1": null,
       "md5": null,
       "sha256": null,
@@ -162,23 +281,17 @@
       "is_key_file": false,
       "license_detection_issues": [
         {
-          "file_regions": [
-            {
-              "start_line": 9,
-              "end_line": 28
-            }
-          ],
           "issue_category": "near-perfect-match-coverage",
           "issue_description": "The license detection is conclusive with a medium confidence because because most, but not all of the rule text is matched.",
           "issue_type": {
             "classification_id": "notice-and-or-with-notice",
             "classification_description": "A notice with a complex license expression (i.e. exceptions, choices or combinations).",
             "analysis_confidence": "high",
-            "is_license_intro": false,
             "is_license_text": false,
             "is_license_notice": true,
             "is_license_tag": false,
             "is_license_reference": false,
+            "is_license_intro": false,
             "is_suggested_matched_text_complete": true
           },
           "suggested_license": {
@@ -187,22 +300,28 @@
           },
           "original_licenses": [
             {
+              "license_expression": "lgpl-2.0-plus WITH libtool-exception-2.0",
               "score": 95.84,
               "start_line": 9,
               "end_line": 28,
               "rule_identifier": "lgpl-2.0-plus_with_libtool-exception-2.0_2.RULE",
-              "license_expression": "lgpl-2.0-plus WITH libtool-exception-2.0",
               "is_license_text": false,
               "is_license_notice": true,
               "is_license_reference": false,
               "is_license_tag": false,
               "is_license_intro": false,
               "matcher": "3-seq",
-              "rule_length": 188,
               "matched_length": 182,
+              "rule_length": 188,
               "match_coverage": 96.81,
               "rule_relevance": 99,
               "matched_text": "GNU Libltdl is free software; you can redistribute it and/or\nmodify it under the terms of the GNU Lesser General Public\nLicense as published by the Free Software Foundation; either\nversion 2 of the License, or (at your option) any later version.\n\nAs a special exception to the GNU Lesser General Public License,\nif you distribute this file as part of a program or library that\nis built using GNU Libtool, you may include this file under the\nsame distribution terms that you use for the rest of that program.\n\nGNU Libltdl is distributed in the hope that it will be useful,\nbut WITHOUT ANY WARRANTY; without even the implied warranty of\nMERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\nGNU Lesser General Public License for more details.\n\nYou should have received a copy of the GNU Lesser General Public\nLicense along with GNU Libltdl; see the file COPYING.LIB.  If not, a\ncopy can be downloaded from  http://www.gnu.org/licenses/lgpl.html,\nor obtained by writing to the Free Software Foundation, Inc.,\n51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA."
+            }
+          ],
+          "file_regions": [
+            {
+              "start_line": 9,
+              "end_line": 28
             }
           ]
         }
@@ -244,8 +363,8 @@
           "homepage_url": "http://www.opensource.org/licenses/BSD-3-Clause",
           "text_url": "http://www.opensource.org/licenses/BSD-3-Clause",
           "reference_url": "https://scancode-licensedb.aboutcode.org/bsd-new",
-          "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/bsd-new.yml",
           "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/bsd-new.LICENSE",
+          "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/bsd-new.yml",
           "spdx_license_key": "BSD-3-Clause",
           "spdx_url": "https://spdx.org/licenses/BSD-3-Clause",
           "start_line": 5,
@@ -258,11 +377,11 @@
               "gpl-2.0-plus",
               "bison-exception-2.2"
             ],
-            "is_license_intro": false,
             "is_license_text": false,
             "is_license_notice": true,
             "is_license_reference": false,
             "is_license_tag": false,
+            "is_license_intro": false,
             "matcher": "2-aho",
             "rule_length": 290,
             "matched_length": 290,
@@ -282,8 +401,8 @@
           "homepage_url": "http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
           "text_url": "http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
           "reference_url": "https://scancode-licensedb.aboutcode.org/gpl-2.0-plus",
-          "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/gpl-2.0-plus.yml",
           "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/gpl-2.0-plus.LICENSE",
+          "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/gpl-2.0-plus.yml",
           "spdx_license_key": "GPL-2.0-or-later",
           "spdx_url": "https://spdx.org/licenses/GPL-2.0-or-later",
           "start_line": 5,
@@ -296,11 +415,11 @@
               "gpl-2.0-plus",
               "bison-exception-2.2"
             ],
-            "is_license_intro": false,
             "is_license_text": false,
             "is_license_notice": true,
             "is_license_reference": false,
             "is_license_tag": false,
+            "is_license_intro": false,
             "matcher": "2-aho",
             "rule_length": 290,
             "matched_length": 290,
@@ -320,8 +439,8 @@
           "homepage_url": null,
           "text_url": "",
           "reference_url": "https://scancode-licensedb.aboutcode.org/bison-exception-2.2",
-          "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/bison-exception-2.2.yml",
           "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/bison-exception-2.2.LICENSE",
+          "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/bison-exception-2.2.yml",
           "spdx_license_key": "Bison-exception-2.2",
           "spdx_url": "https://spdx.org/licenses/Bison-exception-2.2",
           "start_line": 5,
@@ -334,11 +453,11 @@
               "gpl-2.0-plus",
               "bison-exception-2.2"
             ],
-            "is_license_intro": false,
             "is_license_text": false,
             "is_license_notice": true,
             "is_license_reference": false,
             "is_license_tag": false,
+            "is_license_intro": false,
             "matcher": "2-aho",
             "rule_length": 290,
             "matched_length": 290,
@@ -358,8 +477,8 @@
           "homepage_url": "http://www.opensource.org/licenses/BSD-3-Clause",
           "text_url": "http://www.opensource.org/licenses/BSD-3-Clause",
           "reference_url": "https://scancode-licensedb.aboutcode.org/bsd-new",
-          "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/bsd-new.yml",
           "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/bsd-new.LICENSE",
+          "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/bsd-new.yml",
           "spdx_license_key": "BSD-3-Clause",
           "spdx_url": "https://spdx.org/licenses/BSD-3-Clause",
           "start_line": 126,
@@ -370,11 +489,11 @@
             "licenses": [
               "bsd-new"
             ],
-            "is_license_intro": false,
             "is_license_text": false,
             "is_license_notice": true,
             "is_license_reference": false,
             "is_license_tag": false,
+            "is_license_intro": false,
             "matcher": "2-aho",
             "rule_length": 41,
             "matched_length": 41,
@@ -432,8 +551,8 @@
           "homepage_url": "http://www.gnu.org/licenses/gpl-3.0-standalone.html",
           "text_url": "http://www.gnu.org/licenses/gpl-3.0-standalone.html",
           "reference_url": "https://scancode-licensedb.aboutcode.org/gpl-3.0-plus",
-          "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/gpl-3.0-plus.yml",
           "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/gpl-3.0-plus.LICENSE",
+          "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/gpl-3.0-plus.yml",
           "spdx_license_key": "GPL-3.0-or-later",
           "spdx_url": "https://spdx.org/licenses/GPL-3.0-or-later",
           "start_line": 11,
@@ -444,11 +563,11 @@
             "licenses": [
               "gpl-3.0-plus"
             ],
-            "is_license_intro": false,
             "is_license_text": false,
             "is_license_notice": true,
             "is_license_reference": false,
             "is_license_tag": false,
+            "is_license_intro": false,
             "matcher": "3-seq",
             "rule_length": 186,
             "matched_length": 178,
@@ -468,8 +587,8 @@
           "homepage_url": "http://www.gnu.org/licenses/gpl-3.0-standalone.html",
           "text_url": "http://www.gnu.org/licenses/gpl-3.0-standalone.html",
           "reference_url": "https://scancode-licensedb.aboutcode.org/gpl-3.0-plus",
-          "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/gpl-3.0-plus.yml",
           "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/gpl-3.0-plus.LICENSE",
+          "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/gpl-3.0-plus.yml",
           "spdx_license_key": "GPL-3.0-or-later",
           "spdx_url": "https://spdx.org/licenses/GPL-3.0-or-later",
           "start_line": 54,
@@ -480,11 +599,11 @@
             "licenses": [
               "gpl-3.0-plus"
             ],
-            "is_license_intro": false,
             "is_license_text": false,
             "is_license_notice": true,
             "is_license_reference": false,
             "is_license_tag": false,
+            "is_license_intro": false,
             "matcher": "2-aho",
             "rule_length": 100,
             "matched_length": 100,
@@ -506,23 +625,17 @@
       "is_key_file": false,
       "license_detection_issues": [
         {
-          "file_regions": [
-            {
-              "start_line": 11,
-              "end_line": 34
-            }
-          ],
           "issue_category": "near-perfect-match-coverage",
           "issue_description": "The license detection is conclusive with a medium confidence because because most, but not all of the rule text is matched.",
           "issue_type": {
             "classification_id": "notice-single-key-notice",
             "classification_description": "A notice with a single license.",
-            "is_license_intro": false,
-            "is_license_notice": true,
-            "is_license_reference": false,
-            "is_license_tag": false,
-            "is_license_text": false,
             "analysis_confidence": "high",
+            "is_license_text": false,
+            "is_license_notice": true,
+            "is_license_tag": false,
+            "is_license_reference": false,
+            "is_license_intro": false,
             "is_suggested_matched_text_complete": true
           },
           "suggested_license": {
@@ -531,22 +644,28 @@
           },
           "original_licenses": [
             {
+              "license_expression": "gpl-3.0-plus",
               "score": 95.7,
               "start_line": 11,
               "end_line": 34,
               "rule_identifier": "gpl-3.0-plus_209.RULE",
-              "license_expression": "gpl-3.0-plus",
-              "is_license_intro": false,
               "is_license_text": false,
               "is_license_notice": true,
               "is_license_reference": false,
               "is_license_tag": false,
+              "is_license_intro": false,
               "matcher": "3-seq",
-              "rule_length": 186,
               "matched_length": 178,
+              "rule_length": 186,
               "match_coverage": 95.7,
               "rule_relevance": 100,
               "matched_text": " *  AutoOpts is a copyrighted work.  This source file is not encumbered\n *  by AutoOpts licensing, but is provided under the licensing terms chosen\n *  by the genshellopt author or copyright holder.  AutoOpts is\n *  licensed under the terms of the LGPL.  The redistributable library\n *  (``libopts'') is licensed under the terms of either the LGPL or, at the\n *  users discretion, the BSD license.  See the AutoOpts and/or libopts sources\n *  for details.\n *\n * This source file is copyrighted and licensed under the following terms:\n *\n * genshellopt copyright (c) 1999-2009 Bruce Korb - all rights reserved\n *\n * genshellopt is free software: you can redistribute it and/or modify it\n * under the terms of the GNU General Public License as published by the\n * Free Software Foundation, either version 3 of the License, or\n * (at your option) any later version.\n * \n * genshellopt is distributed in the hope that it will be useful, but\n * WITHOUT ANY WARRANTY; without even the implied warranty of\n * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.\n * See the GNU General Public License for more details.\n * \n * You should have received a copy of the GNU General Public License along\n * with this program.  If not, see <http://www.gnu.org/licenses/>."
+            }
+          ],
+          "file_regions": [
+            {
+              "start_line": 11,
+              "end_line": 34
             }
           ]
         }
@@ -557,125 +676,5 @@
       "size_count": 0,
       "scan_errors": []
     }
-  ],
-  "license_detection_issues_summary": {
-    "statistics": {
-        "total_files_with_license": 3,
-        "total_files_with_license_detection_issues": 2,
-        "total_unique_license_detection_issues": 2,
-        "issue_category_counts": {
-            "near-perfect-match-coverage": 2
-        },
-        "issue_classification_id_counts": {
-            "notice-single-key-notice": 1,
-            "notice-and-or-with-notice": 1
-        }, 
-        "analysis_confidence_counts": {
-            "high": 2
-        },
-        "license_info_type_counts": {
-            "license_notice": 2
-        }
-    },
-    "unique_license_detection_issues": [
-      {
-          "unique_identifier": 1,
-          "files": [
-            {
-              "path": "scan-files/1912-libtool-2.2.10-argz.c",
-              "start_line": 9,
-              "end_line": 28
-            }
-          ],
-          "license_detection_issue": {
-            "issue_category": "near-perfect-match-coverage",
-            "issue_description": "The license detection is conclusive with a medium confidence because because most, but not all of the rule text is matched.",
-            "issue_type": {
-              "classification_id": "notice-and-or-with-notice",
-              "classification_description": "A notice with a complex license expression (i.e. exceptions, choices or combinations).",
-              "analysis_confidence": "high",
-              "is_license_intro": false,
-              "is_license_text": false,
-              "is_license_notice": true,
-              "is_license_tag": false,
-              "is_license_reference": false,
-              "is_suggested_matched_text_complete": true
-            },
-            "suggested_license": {
-              "license_expression": "lgpl-2.0-plus WITH libtool-exception-2.0",
-              "matched_text": "GNU Libltdl is free software; you can redistribute it and/or\nmodify it under the terms of the GNU Lesser General Public\nLicense as published by the Free Software Foundation; either\nversion 2 of the License, or (at your option) any later version.\n\nAs a special exception to the GNU Lesser General Public License,\nif you distribute this file as part of a program or library that\nis built using GNU Libtool, you may include this file under the\nsame distribution terms that you use for the rest of that program.\n\nGNU Libltdl is distributed in the hope that it will be useful,\nbut WITHOUT ANY WARRANTY; without even the implied warranty of\nMERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\nGNU Lesser General Public License for more details.\n\nYou should have received a copy of the GNU Lesser General Public\nLicense along with GNU Libltdl; see the file COPYING.LIB.  If not, a\ncopy can be downloaded from  http://www.gnu.org/licenses/lgpl.html,\nor obtained by writing to the Free Software Foundation, Inc.,\n51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA."
-            },
-            "original_licenses": [
-              {
-                "score": 95.84,
-                "start_line": 9,
-                "end_line": 28,
-                "rule_identifier": "lgpl-2.0-plus_with_libtool-exception-2.0_2.RULE",
-                "license_expression": "lgpl-2.0-plus WITH libtool-exception-2.0",
-                "is_license_text": false,
-                "is_license_notice": true,
-                "is_license_reference": false,
-                "is_license_tag": false,
-                "is_license_intro": false,
-                "matcher": "3-seq",
-                "rule_length": 188,
-                "matched_length": 182,
-                "match_coverage": 96.81,
-                "rule_relevance": 99,
-                "matched_text": "GNU Libltdl is free software; you can redistribute it and/or\nmodify it under the terms of the GNU Lesser General Public\nLicense as published by the Free Software Foundation; either\nversion 2 of the License, or (at your option) any later version.\n\nAs a special exception to the GNU Lesser General Public License,\nif you distribute this file as part of a program or library that\nis built using GNU Libtool, you may include this file under the\nsame distribution terms that you use for the rest of that program.\n\nGNU Libltdl is distributed in the hope that it will be useful,\nbut WITHOUT ANY WARRANTY; without even the implied warranty of\nMERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\nGNU Lesser General Public License for more details.\n\nYou should have received a copy of the GNU Lesser General Public\nLicense along with GNU Libltdl; see the file COPYING.LIB.  If not, a\ncopy can be downloaded from  http://www.gnu.org/licenses/lgpl.html,\nor obtained by writing to the Free Software Foundation, Inc.,\n51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA."
-              }
-            ]
-          }
-      },
-      {
-        "unique_identifier": 2,
-        "files": [
-          {
-            "path": "scan-files/genshell.c",
-            "start_line": 11,
-            "end_line": 34
-          }
-        ],
-        "license_detection_issue": {
-          "issue_category": "near-perfect-match-coverage",
-          "issue_description": "The license detection is conclusive with a medium confidence because because most, but not all of the rule text is matched.",
-          "issue_type": {
-            "classification_id": "notice-single-key-notice",
-            "classification_description": "A notice with a single license.",
-            "is_license_intro": false,
-            "is_license_notice": true,
-            "is_license_reference": false,
-            "is_license_tag": false,
-            "is_license_text": false,
-            "analysis_confidence": "high",
-            "is_suggested_matched_text_complete": true
-          },
-          "suggested_license": {
-            "license_expression": "gpl-3.0-plus",
-            "matched_text": " *  AutoOpts is a copyrighted work.  This source file is not encumbered\n *  by AutoOpts licensing, but is provided under the licensing terms chosen\n *  by the genshellopt author or copyright holder.  AutoOpts is\n *  licensed under the terms of the LGPL.  The redistributable library\n *  (``libopts'') is licensed under the terms of either the LGPL or, at the\n *  users discretion, the BSD license.  See the AutoOpts and/or libopts sources\n *  for details.\n *\n * This source file is copyrighted and licensed under the following terms:\n *\n * genshellopt copyright (c) 1999-2009 Bruce Korb - all rights reserved\n *\n * genshellopt is free software: you can redistribute it and/or modify it\n * under the terms of the GNU General Public License as published by the\n * Free Software Foundation, either version 3 of the License, or\n * (at your option) any later version.\n * \n * genshellopt is distributed in the hope that it will be useful, but\n * WITHOUT ANY WARRANTY; without even the implied warranty of\n * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.\n * See the GNU General Public License for more details.\n * \n * You should have received a copy of the GNU General Public License along\n * with this program.  If not, see <http://www.gnu.org/licenses/>."
-          },
-          "original_licenses": [
-            {
-              "score": 95.7,
-              "start_line": 11,
-              "end_line": 34,
-              "rule_identifier": "gpl-3.0-plus_209.RULE",
-              "license_expression": "gpl-3.0-plus",
-              "is_license_intro": false,
-              "is_license_text": false,
-              "is_license_notice": true,
-              "is_license_reference": false,
-              "is_license_tag": false,
-              "matcher": "3-seq",
-              "rule_length": 186,
-              "matched_length": 178,
-              "match_coverage": 95.7,
-              "rule_relevance": 100,
-              "matched_text": " *  AutoOpts is a copyrighted work.  This source file is not encumbered\n *  by AutoOpts licensing, but is provided under the licensing terms chosen\n *  by the genshellopt author or copyright holder.  AutoOpts is\n *  licensed under the terms of the LGPL.  The redistributable library\n *  (``libopts'') is licensed under the terms of either the LGPL or, at the\n *  users discretion, the BSD license.  See the AutoOpts and/or libopts sources\n *  for details.\n *\n * This source file is copyrighted and licensed under the following terms:\n *\n * genshellopt copyright (c) 1999-2009 Bruce Korb - all rights reserved\n *\n * genshellopt is free software: you can redistribute it and/or modify it\n * under the terms of the GNU General Public License as published by the\n * Free Software Foundation, either version 3 of the License, or\n * (at your option) any later version.\n * \n * genshellopt is distributed in the hope that it will be useful, but\n * WITHOUT ANY WARRANTY; without even the implied warranty of\n * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.\n * See the GNU General Public License for more details.\n * \n * You should have received a copy of the GNU General Public License along\n * with this program.  If not, see <http://www.gnu.org/licenses/>."
-            }
-          ]
-        }
-      }
-    ]
-  }
+  ]
 }

--- a/tests/data/analyzer-plugins/results_analyzer_from_sample_json_expected.json
+++ b/tests/data/analyzer-plugins/results_analyzer_from_sample_json_expected.json
@@ -2,7 +2,6 @@
   "headers": [
     {
       "tool_name": "scancode-toolkit",
-      "tool_version": "3.2.3",
       "options": {
         "input": "<path>",
         "--classify": true,
@@ -13,9 +12,6 @@
         "--license-text": true
       },
       "notice": "Generated with ScanCode and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied. No content created from\nScanCode should be considered or used as legal advice. Consult an Attorney\nfor any legal advice.\nScanCode is a free software code scanning tool from nexB Inc. and others.\nVisit https://github.com/nexB/scancode-toolkit/ for support and download.",
-      "start_timestamp": null,
-      "end_timestamp": null,
-      "duration": null,
       "message": null,
       "errors": [],
       "extra_data": {
@@ -24,13 +20,10 @@
     },
     {
       "tool_name": "scancode-toolkit",
-      "tool_version": "3.2.3",
       "options": {
         "input": "<path>",
         "--analyze-license-results": true,
-        "--from-json": [
-          true
-        ],
+        "--from-json": true,
         "--json-pp": "<file>"
       },
       "notice": "Generated with ScanCode and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied. No content created from\nScanCode should be considered or used as legal advice. Consult an Attorney\nfor any legal advice.\nScanCode is a free software code scanning tool from nexB Inc. and others.\nVisit https://github.com/nexB/scancode-toolkit/ for support and download.",
@@ -41,6 +34,285 @@
       }
     }
   ],
+  "license_detection_issues_summary": {
+    "statistics": {
+      "total_files_with_license": 3,
+      "total_files_with_license_detection_issues": 2,
+      "total_unique_license_detection_issues": 3,
+      "issue_category_counts": {
+        "imperfect-match-coverage": 2,
+        "extra-words": 1
+      },
+      "issue_classification_id_counts": {
+        "notice-single-key-notice": 2,
+        "notice-has-unknown-match": 1
+      },
+      "analysis_confidence_counts": {
+        "high": 2,
+        "medium": 1
+      },
+      "license_info_type_counts": {
+        "license_notice": 3
+      }
+    },
+    "unique_license_detection_issues": [
+      {
+        "unique_identifier": 1,
+        "license_detection_issue": {
+          "issue_category": "imperfect-match-coverage",
+          "issue_description": "The license detection is inconclusive with high confidence, because only a small part of the rule text is matched.",
+          "issue_type": {
+            "classification_id": "notice-single-key-notice",
+            "classification_description": "A notice with a single license.",
+            "analysis_confidence": "high",
+            "is_license_text": false,
+            "is_license_notice": true,
+            "is_license_tag": false,
+            "is_license_reference": false,
+            "is_license_intro": false,
+            "is_suggested_matched_text_complete": true
+          },
+          "suggested_license": {
+            "license_expression": "gpl-2.0",
+            "matched_text": "/* Published under the GNU General Public License V.2, see file COPYING */"
+          },
+          "original_licenses": [
+            {
+              "license_expression": "gpl-2.0",
+              "score": 20.59,
+              "start_line": 3,
+              "end_line": 3,
+              "rule_identifier": "gpl-2.0_394.RULE",
+              "is_license_text": false,
+              "is_license_notice": true,
+              "is_license_reference": false,
+              "is_license_tag": false,
+              "is_license_intro": false,
+              "matcher": "3-seq",
+              "matched_length": 7,
+              "rule_length": 34,
+              "match_coverage": 20.59,
+              "rule_relevance": 100,
+              "matched_text": "/* Published under the GNU General Public License V.2, see file COPYING */"
+            }
+          ]
+        },
+        "files": [
+          {
+            "path": "scan-files/1921-socat-2.0.0-error.h",
+            "start_line": 3,
+            "end_line": 3
+          }
+        ]
+      },
+      {
+        "unique_identifier": 2,
+        "license_detection_issue": {
+          "issue_category": "imperfect-match-coverage",
+          "issue_description": "The license detection is inconclusive with high confidence, because only a small part of the rule text is matched.",
+          "issue_type": {
+            "classification_id": "notice-has-unknown-match",
+            "classification_description": "License notices with unknown licenses detected.",
+            "analysis_confidence": "medium",
+            "is_license_text": false,
+            "is_license_notice": true,
+            "is_license_tag": false,
+            "is_license_reference": false,
+            "is_license_intro": false,
+            "is_suggested_matched_text_complete": true
+          },
+          "suggested_license": {
+            "license_expression": "lgpl-2.0-plus",
+            "matched_text": " *  licensed under the terms of the LGPL.  The redistributable library\n *  (``libopts'') is licensed under the terms of either the LGPL or, at the\n *  users discretion, the BSD license.  See the AutoOpts and/or libopts sources\n *  for details.\n *\n * This source file is copyrighted and licensed under the following terms:\n *\n * genshellopt copyright (c) 1999-2009 Bruce Korb - all rights reserved\n *\n * genshellopt is free software: you can redistribute it and/or modify it\n * under the terms of the GNU General Public License as published by the\n * Free Software Foundation, either version 3 of the License, or\n * (at your option) any later version.\n * \n * genshellopt is distributed in the hope that it will be useful, but\n * WITHOUT ANY WARRANTY; without even the implied warranty of\n * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.\n * See the GNU General Public License for more details.\n * \n * You should have received a copy of the GNU General Public License along\n * with this program.  If not, see <http://www.gnu.org/licenses/>."
+          },
+          "original_licenses": [
+            {
+              "license_expression": "unknown",
+              "score": 27.0,
+              "start_line": 14,
+              "end_line": 14,
+              "rule_identifier": "lead-in_unknown_67.RULE",
+              "is_license_text": false,
+              "is_license_notice": false,
+              "is_license_reference": true,
+              "is_license_tag": false,
+              "is_license_intro": false,
+              "matcher": "2-aho",
+              "matched_length": 5,
+              "rule_length": 5,
+              "match_coverage": 100.0,
+              "rule_relevance": 27,
+              "matched_text": " *  licensed under the terms of the LGPL.  The redistributable library"
+            },
+            {
+              "license_expression": "lgpl-2.0-plus",
+              "score": 5.0,
+              "start_line": 14,
+              "end_line": 14,
+              "rule_identifier": "lgpl_bare_single_word.RULE",
+              "is_license_text": false,
+              "is_license_notice": false,
+              "is_license_reference": true,
+              "is_license_tag": false,
+              "is_license_intro": false,
+              "matcher": "2-aho",
+              "matched_length": 1,
+              "rule_length": 1,
+              "match_coverage": 100.0,
+              "rule_relevance": 5,
+              "matched_text": " *  licensed under the terms of the LGPL.  The redistributable library"
+            },
+            {
+              "license_expression": "unknown",
+              "score": 27.0,
+              "start_line": 15,
+              "end_line": 15,
+              "rule_identifier": "lead-in_unknown_67.RULE",
+              "is_license_text": false,
+              "is_license_notice": false,
+              "is_license_reference": true,
+              "is_license_tag": false,
+              "is_license_intro": false,
+              "matcher": "2-aho",
+              "matched_length": 5,
+              "rule_length": 5,
+              "match_coverage": 100.0,
+              "rule_relevance": 27,
+              "matched_text": " *  (``libopts'') is licensed under the terms of either the LGPL or, at the"
+            },
+            {
+              "license_expression": "lgpl-2.0-plus",
+              "score": 5.0,
+              "start_line": 15,
+              "end_line": 15,
+              "rule_identifier": "lgpl_bare_single_word.RULE",
+              "is_license_text": false,
+              "is_license_notice": false,
+              "is_license_reference": true,
+              "is_license_tag": false,
+              "is_license_intro": false,
+              "matcher": "2-aho",
+              "matched_length": 1,
+              "rule_length": 1,
+              "match_coverage": 100.0,
+              "rule_relevance": 5,
+              "matched_text": " *  (``libopts'') is licensed under the terms of either the LGPL or, at the"
+            },
+            {
+              "license_expression": "bsd-new",
+              "score": 99.0,
+              "start_line": 16,
+              "end_line": 16,
+              "rule_identifier": "bsd-new_145.RULE",
+              "is_license_text": false,
+              "is_license_notice": false,
+              "is_license_reference": true,
+              "is_license_tag": false,
+              "is_license_intro": false,
+              "matcher": "2-aho",
+              "matched_length": 3,
+              "rule_length": 3,
+              "match_coverage": 100.0,
+              "rule_relevance": 99.0,
+              "matched_text": " *  users discretion, the BSD license.  See the AutoOpts and/or libopts sources"
+            },
+            {
+              "license_expression": "agpl-3.0-plus",
+              "score": 90.83,
+              "start_line": 16,
+              "end_line": 34,
+              "rule_identifier": "agpl-3.0-plus_112.RULE",
+              "is_license_text": false,
+              "is_license_notice": true,
+              "is_license_reference": false,
+              "is_license_tag": false,
+              "is_license_intro": false,
+              "matcher": "3-seq",
+              "matched_length": 99,
+              "rule_length": 109,
+              "match_coverage": 90.83,
+              "rule_relevance": 100.0,
+              "matched_text": " *  users discretion, the BSD license.  See the AutoOpts and/or libopts sources\n *  for details.\n *\n * This source file is copyrighted and licensed under the following terms:\n *\n * genshellopt copyright (c) 1999-2009 Bruce Korb - all rights reserved\n *\n * genshellopt is free software: you can redistribute it and/or modify it\n * under the terms of the GNU General Public License as published by the\n * Free Software Foundation, either version 3 of the License, or\n * (at your option) any later version.\n * \n * genshellopt is distributed in the hope that it will be useful, but\n * WITHOUT ANY WARRANTY; without even the implied warranty of\n * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.\n * See the GNU General Public License for more details.\n * \n * You should have received a copy of the GNU General Public License along\n * with this program.  If not, see <http://www.gnu.org/licenses/>."
+            },
+            {
+              "license_expression": "unknown",
+              "score": 27.0,
+              "start_line": 19,
+              "end_line": 19,
+              "rule_identifier": "lead-in_unknown_77.RULE",
+              "is_license_text": false,
+              "is_license_notice": false,
+              "is_license_reference": true,
+              "is_license_tag": false,
+              "is_license_intro": false,
+              "matcher": "2-aho",
+              "matched_length": 5,
+              "rule_length": 5,
+              "match_coverage": 100.0,
+              "rule_relevance": 27,
+              "matched_text": " * This source file is copyrighted and licensed under the following terms:"
+            }
+          ]
+        },
+        "files": [
+          {
+            "path": "scan-files/genshell.c",
+            "start_line": 14,
+            "end_line": 34
+          }
+        ]
+      },
+      {
+        "unique_identifier": 3,
+        "license_detection_issue": {
+          "issue_category": "extra-words",
+          "issue_description": "The license detection is conclusive with high confidence because all the rule text is matched, but some unknown extra words have been inserted in the text.",
+          "issue_type": {
+            "classification_id": "notice-single-key-notice",
+            "classification_description": "A notice with a single license.",
+            "analysis_confidence": "high",
+            "is_license_text": false,
+            "is_license_notice": true,
+            "is_license_tag": false,
+            "is_license_reference": false,
+            "is_license_intro": false,
+            "is_suggested_matched_text_complete": true
+          },
+          "suggested_license": {
+            "license_expression": "gpl-3.0-plus",
+            "matched_text": "\"genshellopt is free software: you can redistribute it and/or modify it under \\\nthe terms of the GNU General Public License as published by the Free Software \\\nFoundation, either version 3 of the License, or (at your option) any later \\\nversion.  \\\ngenshellopt is distributed in the hope that it will be useful, but WITHOUT ANY \\\nWARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A \\\nPARTICULAR PURPOSE.  See the GNU General Public License for more details.  \\\nYou should have received a copy of the GNU General Public License along with \\\nthis program.  If not, see <http://www.gnu.org/licenses/>.\";"
+          },
+          "original_licenses": [
+            {
+              "license_expression": "gpl-3.0-plus",
+              "score": 98.99,
+              "start_line": 54,
+              "end_line": 62,
+              "rule_identifier": "gpl-3.0-plus_27.RULE",
+              "is_license_text": false,
+              "is_license_notice": true,
+              "is_license_reference": false,
+              "is_license_tag": false,
+              "is_license_intro": false,
+              "matcher": "3-seq",
+              "matched_length": 98,
+              "rule_length": 98,
+              "match_coverage": 100.0,
+              "rule_relevance": 100,
+              "matched_text": "\"genshellopt is free software: you can redistribute it and/or modify it under \\\nthe terms of the GNU General Public License as published by the Free Software \\\nFoundation, either version 3 of the License, or (at your option) any later \\\nversion.  \\\ngenshellopt is distributed in the hope that it will be useful, but WITHOUT ANY \\\nWARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A \\\nPARTICULAR PURPOSE.  See the GNU General Public License for more details.  \\\nYou should have received a copy of the GNU General Public License along with \\\nthis program.  If not, see <http://www.gnu.org/licenses/>.\";"
+            }
+          ]
+        },
+        "files": [
+          {
+            "path": "scan-files/genshell.c",
+            "start_line": 54,
+            "end_line": 62
+          }
+        ]
+      }
+    ]
+  },
   "files": [
     {
       "path": "scan-files",
@@ -145,23 +417,17 @@
       "is_license_text": false,
       "license_detection_issues": [
         {
-          "file_regions": [
-            {
-              "start_line": 3,
-              "end_line": 3
-            }
-          ],
           "issue_category": "imperfect-match-coverage",
           "issue_description": "The license detection is inconclusive with high confidence, because only a small part of the rule text is matched.",
           "issue_type": {
             "classification_id": "notice-single-key-notice",
             "classification_description": "A notice with a single license.",
-            "is_license_intro": false,
+            "analysis_confidence": "high",
             "is_license_text": false,
             "is_license_notice": true,
             "is_license_tag": false,
             "is_license_reference": false,
-            "analysis_confidence": "high",
+            "is_license_intro": false,
             "is_suggested_matched_text_complete": true
           },
           "suggested_license": {
@@ -170,22 +436,28 @@
           },
           "original_licenses": [
             {
+              "license_expression": "gpl-2.0",
               "score": 20.59,
               "start_line": 3,
               "end_line": 3,
               "rule_identifier": "gpl-2.0_394.RULE",
-              "license_expression": "gpl-2.0",
               "is_license_text": false,
               "is_license_notice": true,
               "is_license_reference": false,
               "is_license_tag": false,
               "is_license_intro": false,
               "matcher": "3-seq",
-              "rule_length": 34,
               "matched_length": 7,
+              "rule_length": 34,
               "match_coverage": 20.59,
               "rule_relevance": 100,
               "matched_text": "/* Published under the GNU General Public License V.2, see file COPYING */"
+            }
+          ],
+          "file_regions": [
+            {
+              "start_line": 3,
+              "end_line": 3
             }
           ]
         }
@@ -580,23 +852,17 @@
       "is_license_text": false,
       "license_detection_issues": [
         {
-          "file_regions": [
-            {
-              "start_line": 14,
-              "end_line": 34
-            }
-          ],
           "issue_category": "imperfect-match-coverage",
           "issue_description": "The license detection is inconclusive with high confidence, because only a small part of the rule text is matched.",
           "issue_type": {
             "classification_id": "notice-has-unknown-match",
             "classification_description": "License notices with unknown licenses detected.",
-            "is_license_intro": false,
+            "analysis_confidence": "medium",
             "is_license_text": false,
             "is_license_notice": true,
             "is_license_tag": false,
             "is_license_reference": false,
-            "analysis_confidence": "medium",
+            "is_license_intro": false,
             "is_suggested_matched_text_complete": true
           },
           "suggested_license": {
@@ -605,151 +871,151 @@
           },
           "original_licenses": [
             {
+              "license_expression": "unknown",
               "score": 27.0,
               "start_line": 14,
               "end_line": 14,
               "rule_identifier": "lead-in_unknown_67.RULE",
-              "license_expression": "unknown",
               "is_license_text": false,
               "is_license_notice": false,
               "is_license_reference": true,
               "is_license_tag": false,
               "is_license_intro": false,
               "matcher": "2-aho",
-              "rule_length": 5,
               "matched_length": 5,
+              "rule_length": 5,
               "match_coverage": 100.0,
               "rule_relevance": 27,
               "matched_text": " *  licensed under the terms of the LGPL.  The redistributable library"
             },
             {
+              "license_expression": "lgpl-2.0-plus",
               "score": 5.0,
               "start_line": 14,
               "end_line": 14,
               "rule_identifier": "lgpl_bare_single_word.RULE",
-              "license_expression": "lgpl-2.0-plus",
               "is_license_text": false,
               "is_license_notice": false,
               "is_license_reference": true,
               "is_license_tag": false,
               "is_license_intro": false,
               "matcher": "2-aho",
-              "rule_length": 1,
               "matched_length": 1,
+              "rule_length": 1,
               "match_coverage": 100.0,
               "rule_relevance": 5,
               "matched_text": " *  licensed under the terms of the LGPL.  The redistributable library"
             },
             {
+              "license_expression": "unknown",
               "score": 27.0,
               "start_line": 15,
               "end_line": 15,
               "rule_identifier": "lead-in_unknown_67.RULE",
-              "license_expression": "unknown",
               "is_license_text": false,
               "is_license_notice": false,
               "is_license_reference": true,
               "is_license_tag": false,
               "is_license_intro": false,
               "matcher": "2-aho",
-              "rule_length": 5,
               "matched_length": 5,
+              "rule_length": 5,
               "match_coverage": 100.0,
               "rule_relevance": 27,
               "matched_text": " *  (``libopts'') is licensed under the terms of either the LGPL or, at the"
             },
             {
+              "license_expression": "lgpl-2.0-plus",
               "score": 5.0,
               "start_line": 15,
               "end_line": 15,
               "rule_identifier": "lgpl_bare_single_word.RULE",
-              "license_expression": "lgpl-2.0-plus",
               "is_license_text": false,
               "is_license_notice": false,
               "is_license_reference": true,
               "is_license_tag": false,
               "is_license_intro": false,
               "matcher": "2-aho",
-              "rule_length": 1,
               "matched_length": 1,
+              "rule_length": 1,
               "match_coverage": 100.0,
               "rule_relevance": 5,
               "matched_text": " *  (``libopts'') is licensed under the terms of either the LGPL or, at the"
             },
             {
+              "license_expression": "bsd-new",
               "score": 99.0,
               "start_line": 16,
               "end_line": 16,
               "rule_identifier": "bsd-new_145.RULE",
-              "license_expression": "bsd-new",
               "is_license_text": false,
               "is_license_notice": false,
               "is_license_reference": true,
               "is_license_tag": false,
               "is_license_intro": false,
               "matcher": "2-aho",
-              "rule_length": 3,
               "matched_length": 3,
+              "rule_length": 3,
               "match_coverage": 100.0,
               "rule_relevance": 99.0,
               "matched_text": " *  users discretion, the BSD license.  See the AutoOpts and/or libopts sources"
             },
             {
+              "license_expression": "agpl-3.0-plus",
               "score": 90.83,
               "start_line": 16,
               "end_line": 34,
               "rule_identifier": "agpl-3.0-plus_112.RULE",
-              "license_expression": "agpl-3.0-plus",
               "is_license_text": false,
               "is_license_notice": true,
               "is_license_reference": false,
               "is_license_tag": false,
               "is_license_intro": false,
               "matcher": "3-seq",
-              "rule_length": 109,
               "matched_length": 99,
+              "rule_length": 109,
               "match_coverage": 90.83,
               "rule_relevance": 100.0,
               "matched_text": " *  users discretion, the BSD license.  See the AutoOpts and/or libopts sources\n *  for details.\n *\n * This source file is copyrighted and licensed under the following terms:\n *\n * genshellopt copyright (c) 1999-2009 Bruce Korb - all rights reserved\n *\n * genshellopt is free software: you can redistribute it and/or modify it\n * under the terms of the GNU General Public License as published by the\n * Free Software Foundation, either version 3 of the License, or\n * (at your option) any later version.\n * \n * genshellopt is distributed in the hope that it will be useful, but\n * WITHOUT ANY WARRANTY; without even the implied warranty of\n * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.\n * See the GNU General Public License for more details.\n * \n * You should have received a copy of the GNU General Public License along\n * with this program.  If not, see <http://www.gnu.org/licenses/>."
             },
             {
+              "license_expression": "unknown",
               "score": 27.0,
               "start_line": 19,
               "end_line": 19,
               "rule_identifier": "lead-in_unknown_77.RULE",
-              "license_expression": "unknown",
               "is_license_text": false,
               "is_license_notice": false,
               "is_license_reference": true,
               "is_license_tag": false,
               "is_license_intro": false,
               "matcher": "2-aho",
-              "rule_length": 5,
               "matched_length": 5,
+              "rule_length": 5,
               "match_coverage": 100.0,
               "rule_relevance": 27,
               "matched_text": " * This source file is copyrighted and licensed under the following terms:"
             }
+          ],
+          "file_regions": [
+            {
+              "start_line": 14,
+              "end_line": 34
+            }
           ]
         },
         {
-          "file_regions": [
-            {
-              "start_line": 54,
-              "end_line": 62
-            }
-          ],
           "issue_category": "extra-words",
           "issue_description": "The license detection is conclusive with high confidence because all the rule text is matched, but some unknown extra words have been inserted in the text.",
           "issue_type": {
             "classification_id": "notice-single-key-notice",
-            "classification_description":  "A notice with a single license.",
-            "is_license_intro": false,
+            "classification_description": "A notice with a single license.",
+            "analysis_confidence": "high",
             "is_license_text": false,
             "is_license_notice": true,
             "is_license_tag": false,
             "is_license_reference": false,
-            "analysis_confidence": "high",
+            "is_license_intro": false,
             "is_suggested_matched_text_complete": true
           },
           "suggested_license": {
@@ -758,22 +1024,28 @@
           },
           "original_licenses": [
             {
+              "license_expression": "gpl-3.0-plus",
               "score": 98.99,
               "start_line": 54,
               "end_line": 62,
               "rule_identifier": "gpl-3.0-plus_27.RULE",
-              "license_expression": "gpl-3.0-plus",
               "is_license_text": false,
               "is_license_notice": true,
               "is_license_reference": false,
               "is_license_tag": false,
               "is_license_intro": false,
               "matcher": "3-seq",
-              "rule_length": 98,
               "matched_length": 98,
+              "rule_length": 98,
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "matched_text": "\"genshellopt is free software: you can redistribute it and/or modify it under \\\nthe terms of the GNU General Public License as published by the Free Software \\\nFoundation, either version 3 of the License, or (at your option) any later \\\nversion.  \\\ngenshellopt is distributed in the hope that it will be useful, but WITHOUT ANY \\\nWARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A \\\nPARTICULAR PURPOSE.  See the GNU General Public License for more details.  \\\nYou should have received a copy of the GNU General Public License along with \\\nthis program.  If not, see <http://www.gnu.org/licenses/>.\";"
+            }
+          ],
+          "file_regions": [
+            {
+              "start_line": 54,
+              "end_line": 62
             }
           ]
         }
@@ -783,284 +1055,5 @@
       "size_count": 0,
       "scan_errors": []
     }
-  ],
-  "license_detection_issues_summary": {
-    "statistics": {
-        "total_files_with_license": 3,
-        "total_files_with_license_detection_issues": 2,
-        "total_unique_license_detection_issues": 3,
-        "issue_category_counts": {
-            "imperfect-match-coverage": 2,
-            "extra-words": 1
-        },
-        "issue_classification_id_counts": {
-            "notice-single-key-notice": 2,
-            "notice-has-unknown-match": 1
-        }, 
-        "analysis_confidence_counts": {
-            "high": 2,
-            "medium": 1
-        },
-        "license_info_type_counts": {
-            "license_notice": 3
-        }
-    },
-    "unique_license_detection_issues": [
-      {
-          "unique_identifier": 1,
-          "files": [
-            {
-              "path": "scan-files/1921-socat-2.0.0-error.h",
-              "start_line": 3,
-              "end_line": 3
-            }
-          ],
-          "license_detection_issue": {
-            "issue_category": "imperfect-match-coverage",
-            "issue_description": "The license detection is inconclusive with high confidence, because only a small part of the rule text is matched.",
-            "issue_type": {
-              "classification_id": "notice-single-key-notice",
-              "classification_description": "A notice with a single license.",
-              "is_license_intro": false,
-              "is_license_text": false,
-              "is_license_notice": true,
-              "is_license_tag": false,
-              "is_license_reference": false,
-              "analysis_confidence": "high",
-              "is_suggested_matched_text_complete": true
-            },
-            "suggested_license": {
-              "license_expression": "gpl-2.0",
-              "matched_text": "/* Published under the GNU General Public License V.2, see file COPYING */"
-            },
-            "original_licenses": [
-              {
-                "score": 20.59,
-                "start_line": 3,
-                "end_line": 3,
-                "rule_identifier": "gpl-2.0_394.RULE",
-                "license_expression": "gpl-2.0",
-                "is_license_text": false,
-                "is_license_notice": true,
-                "is_license_reference": false,
-                "is_license_tag": false,
-                "is_license_intro": false,
-                "matcher": "3-seq",
-                "rule_length": 34,
-                "matched_length": 7,
-                "match_coverage": 20.59,
-                "rule_relevance": 100,
-                "matched_text": "/* Published under the GNU General Public License V.2, see file COPYING */"
-              }
-            ]
-          }
-      },
-      {
-        "unique_identifier": 2,
-        "files": [
-          {
-            "path": "scan-files/genshell.c",
-            "start_line": 14,
-            "end_line": 34
-          }
-        ],
-        "license_detection_issue": {
-          "issue_category": "imperfect-match-coverage",
-          "issue_description": "The license detection is inconclusive with high confidence, because only a small part of the rule text is matched.",
-          "issue_type": {
-            "classification_id": "notice-has-unknown-match",
-            "classification_description": "License notices with unknown licenses detected.",
-            "is_license_intro": false,
-            "is_license_text": false,
-            "is_license_notice": true,
-            "is_license_tag": false,
-            "is_license_reference": false,
-            "analysis_confidence": "medium",
-            "is_suggested_matched_text_complete": true
-          },
-          "suggested_license": {
-            "license_expression": "lgpl-2.0-plus",
-            "matched_text": " *  licensed under the terms of the LGPL.  The redistributable library\n *  (``libopts'') is licensed under the terms of either the LGPL or, at the\n *  users discretion, the BSD license.  See the AutoOpts and/or libopts sources\n *  for details.\n *\n * This source file is copyrighted and licensed under the following terms:\n *\n * genshellopt copyright (c) 1999-2009 Bruce Korb - all rights reserved\n *\n * genshellopt is free software: you can redistribute it and/or modify it\n * under the terms of the GNU General Public License as published by the\n * Free Software Foundation, either version 3 of the License, or\n * (at your option) any later version.\n * \n * genshellopt is distributed in the hope that it will be useful, but\n * WITHOUT ANY WARRANTY; without even the implied warranty of\n * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.\n * See the GNU General Public License for more details.\n * \n * You should have received a copy of the GNU General Public License along\n * with this program.  If not, see <http://www.gnu.org/licenses/>."
-          },
-          "original_licenses": [
-            {
-              "score": 27.0,
-              "start_line": 14,
-              "end_line": 14,
-              "rule_identifier": "lead-in_unknown_67.RULE",
-              "license_expression": "unknown",
-              "is_license_text": false,
-              "is_license_notice": false,
-              "is_license_reference": true,
-              "is_license_tag": false,
-              "is_license_intro": false,
-              "matcher": "2-aho",
-              "rule_length": 5,
-              "matched_length": 5,
-              "match_coverage": 100.0,
-              "rule_relevance": 27,
-              "matched_text": " *  licensed under the terms of the LGPL.  The redistributable library"
-            },
-            {
-              "score": 5.0,
-              "start_line": 14,
-              "end_line": 14,
-              "rule_identifier": "lgpl_bare_single_word.RULE",
-              "license_expression": "lgpl-2.0-plus",
-              "is_license_text": false,
-              "is_license_notice": false,
-              "is_license_reference": true,
-              "is_license_tag": false,
-              "is_license_intro": false,
-              "matcher": "2-aho",
-              "rule_length": 1,
-              "matched_length": 1,
-              "match_coverage": 100.0,
-              "rule_relevance": 5,
-              "matched_text": " *  licensed under the terms of the LGPL.  The redistributable library"
-            },
-            {
-              "score": 27.0,
-              "start_line": 15,
-              "end_line": 15,
-              "rule_identifier": "lead-in_unknown_67.RULE",
-              "license_expression": "unknown",
-              "is_license_text": false,
-              "is_license_notice": false,
-              "is_license_reference": true,
-              "is_license_tag": false,
-              "is_license_intro": false,
-              "matcher": "2-aho",
-              "rule_length": 5,
-              "matched_length": 5,
-              "match_coverage": 100.0,
-              "rule_relevance": 27,
-              "matched_text": " *  (``libopts'') is licensed under the terms of either the LGPL or, at the"
-            },
-            {
-              "score": 5.0,
-              "start_line": 15,
-              "end_line": 15,
-              "rule_identifier": "lgpl_bare_single_word.RULE",
-              "license_expression": "lgpl-2.0-plus",
-              "is_license_text": false,
-              "is_license_notice": false,
-              "is_license_reference": true,
-              "is_license_tag": false,
-              "is_license_intro": false,
-              "matcher": "2-aho",
-              "rule_length": 1,
-              "matched_length": 1,
-              "match_coverage": 100.0,
-              "rule_relevance": 5,
-              "matched_text": " *  (``libopts'') is licensed under the terms of either the LGPL or, at the"
-            },
-            {
-              "score": 99.0,
-              "start_line": 16,
-              "end_line": 16,
-              "rule_identifier": "bsd-new_145.RULE",
-              "license_expression": "bsd-new",
-              "is_license_text": false,
-              "is_license_notice": false,
-              "is_license_reference": true,
-              "is_license_tag": false,
-              "is_license_intro": false,
-              "matcher": "2-aho",
-              "rule_length": 3,
-              "matched_length": 3,
-              "match_coverage": 100.0,
-              "rule_relevance": 99.0,
-              "matched_text": " *  users discretion, the BSD license.  See the AutoOpts and/or libopts sources"
-            },
-            {
-              "score": 90.83,
-              "start_line": 16,
-              "end_line": 34,
-              "rule_identifier": "agpl-3.0-plus_112.RULE",
-              "license_expression": "agpl-3.0-plus",
-              "is_license_text": false,
-              "is_license_notice": true,
-              "is_license_reference": false,
-              "is_license_tag": false,
-              "is_license_intro": false,
-              "matcher": "3-seq",
-              "rule_length": 109,
-              "matched_length": 99,
-              "match_coverage": 90.83,
-              "rule_relevance": 100.0,
-              "matched_text": " *  users discretion, the BSD license.  See the AutoOpts and/or libopts sources\n *  for details.\n *\n * This source file is copyrighted and licensed under the following terms:\n *\n * genshellopt copyright (c) 1999-2009 Bruce Korb - all rights reserved\n *\n * genshellopt is free software: you can redistribute it and/or modify it\n * under the terms of the GNU General Public License as published by the\n * Free Software Foundation, either version 3 of the License, or\n * (at your option) any later version.\n * \n * genshellopt is distributed in the hope that it will be useful, but\n * WITHOUT ANY WARRANTY; without even the implied warranty of\n * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.\n * See the GNU General Public License for more details.\n * \n * You should have received a copy of the GNU General Public License along\n * with this program.  If not, see <http://www.gnu.org/licenses/>."
-            },
-            {
-              "score": 27.0,
-              "start_line": 19,
-              "end_line": 19,
-              "rule_identifier": "lead-in_unknown_77.RULE",
-              "license_expression": "unknown",
-              "is_license_text": false,
-              "is_license_notice": false,
-              "is_license_reference": true,
-              "is_license_tag": false,
-              "is_license_intro": false,
-              "matcher": "2-aho",
-              "rule_length": 5,
-              "matched_length": 5,
-              "match_coverage": 100.0,
-              "rule_relevance": 27,
-              "matched_text": " * This source file is copyrighted and licensed under the following terms:"
-            }
-          ]
-        }
-      },
-      {
-        "unique_identifier": 3,
-        "files": [
-          {
-            "path": "scan-files/genshell.c",
-            "start_line": 54,
-            "end_line": 62
-          }
-        ],
-        "license_detection_issue": {
-          "issue_category": "extra-words",
-          "issue_description": "The license detection is conclusive with high confidence because all the rule text is matched, but some unknown extra words have been inserted in the text.",
-          "issue_type": {
-            "classification_id": "notice-single-key-notice",
-            "classification_description":  "A notice with a single license.",
-            "is_license_intro": false,
-            "is_license_text": false,
-            "is_license_notice": true,
-            "is_license_tag": false,
-            "is_license_reference": false,
-            "analysis_confidence": "high",
-            "is_suggested_matched_text_complete": true
-          },
-          "suggested_license": {
-            "license_expression": "gpl-3.0-plus",
-            "matched_text": "\"genshellopt is free software: you can redistribute it and/or modify it under \\\nthe terms of the GNU General Public License as published by the Free Software \\\nFoundation, either version 3 of the License, or (at your option) any later \\\nversion.  \\\ngenshellopt is distributed in the hope that it will be useful, but WITHOUT ANY \\\nWARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A \\\nPARTICULAR PURPOSE.  See the GNU General Public License for more details.  \\\nYou should have received a copy of the GNU General Public License along with \\\nthis program.  If not, see <http://www.gnu.org/licenses/>.\";"
-          },
-          "original_licenses": [
-            {
-              "score": 98.99,
-              "start_line": 54,
-              "end_line": 62,
-              "rule_identifier": "gpl-3.0-plus_27.RULE",
-              "license_expression": "gpl-3.0-plus",
-              "is_license_text": false,
-              "is_license_notice": true,
-              "is_license_reference": false,
-              "is_license_tag": false,
-              "is_license_intro": false,
-              "matcher": "3-seq",
-              "rule_length": 98,
-              "matched_length": 98,
-              "match_coverage": 100.0,
-              "rule_relevance": 100,
-              "matched_text": "\"genshellopt is free software: you can redistribute it and/or modify it under \\\nthe terms of the GNU General Public License as published by the Free Software \\\nFoundation, either version 3 of the License, or (at your option) any later \\\nversion.  \\\ngenshellopt is distributed in the hope that it will be useful, but WITHOUT ANY \\\nWARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A \\\nPARTICULAR PURPOSE.  See the GNU General Public License for more details.  \\\nYou should have received a copy of the GNU General Public License along with \\\nthis program.  If not, see <http://www.gnu.org/licenses/>.\";"
-            }
-          ]
-        }
-      }
-    ]
-  }
+  ]
 }

--- a/tests/data/analyzer-plugins/results_analyzer_from_sample_json_expected_summary.json
+++ b/tests/data/analyzer-plugins/results_analyzer_from_sample_json_expected_summary.json
@@ -2,7 +2,6 @@
   "headers": [
     {
       "tool_name": "scancode-toolkit",
-      "tool_version": "3.2.3",
       "options": {
         "input": "<path>",
         "--classify": true,
@@ -13,9 +12,6 @@
         "--license-text": true
       },
       "notice": "Generated with ScanCode and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied. No content created from\nScanCode should be considered or used as legal advice. Consult an Attorney\nfor any legal advice.\nScanCode is a free software code scanning tool from nexB Inc. and others.\nVisit https://github.com/nexB/scancode-toolkit/ for support and download.",
-      "start_timestamp": null,
-      "end_timestamp": null,
-      "duration": null,
       "message": null,
       "errors": [],
       "extra_data": {
@@ -24,13 +20,10 @@
     },
     {
       "tool_name": "scancode-toolkit",
-      "tool_version": "21.2.9",
       "options": {
         "input": "<path>",
         "--analyze-license-results": true,
-        "--from-json": [
-          true
-        ],
+        "--from-json": true,
         "--json-pp": "<file>"
       },
       "notice": "Generated with ScanCode and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied. No content created from\nScanCode should be considered or used as legal advice. Consult an Attorney\nfor any legal advice.\nScanCode is a free software code scanning tool from nexB Inc. and others.\nVisit https://github.com/nexB/scancode-toolkit/ for support and download.",
@@ -62,6 +55,63 @@
     "unique_license_detection_issues": [
       {
         "unique_identifier": 1,
+        "license_detection_issue": {
+          "issue_category": "imperfect-match-coverage",
+          "issue_description": "The license detection is inconclusive with high confidence, because only a small part of the rule text is matched.",
+          "issue_type": {
+            "classification_id": "notice-single-key-notice",
+            "classification_description": "A notice with a single license.",
+            "analysis_confidence": "high",
+            "is_license_text": false,
+            "is_license_notice": true,
+            "is_license_tag": false,
+            "is_license_reference": false,
+            "is_license_intro": false,
+            "is_suggested_matched_text_complete": true
+          },
+          "suggested_license": {
+            "license_expression": "gpl-3.0-plus WITH tex-exception",
+            "matched_text": "# Published under the GNU General Public License V.2, see file COPYING"
+          },
+          "original_licenses": [
+            {
+              "license_expression": "gpl-3.0-plus WITH tex-exception",
+              "score": 13.21,
+              "start_line": 4,
+              "end_line": 4,
+              "rule_identifier": "gpl-3.0-plus_with_tex-exception_4.RULE",
+              "is_license_text": false,
+              "is_license_notice": true,
+              "is_license_reference": false,
+              "is_license_tag": false,
+              "is_license_intro": false,
+              "matcher": "3-seq",
+              "matched_length": 7,
+              "rule_length": 53,
+              "match_coverage": 13.21,
+              "rule_relevance": 100,
+              "matched_text": "# Published under the GNU General Public License V.2, see file COPYING"
+            },
+            {
+              "license_expression": "gpl-2.0",
+              "score": 100.0,
+              "start_line": 4,
+              "end_line": 4,
+              "rule_identifier": "gpl-2.0_756.RULE",
+              "is_license_text": false,
+              "is_license_notice": false,
+              "is_license_reference": true,
+              "is_license_tag": false,
+              "is_license_intro": false,
+              "matcher": "2-aho",
+              "matched_length": 6,
+              "rule_length": 6,
+              "match_coverage": 100.0,
+              "rule_relevance": 100.0,
+              "matched_text": "# Published under the GNU General Public License V.2, see file COPYING"
+            }
+          ]
+        },
         "files": [
           {
             "path": "issues-files/socat-2.0.0-gatherinfo.sh",
@@ -78,7 +128,10 @@
             "start_line": 3,
             "end_line": 3
           }
-        ],
+        ]
+      },
+      {
+        "unique_identifier": 2,
         "license_detection_issue": {
           "issue_category": "imperfect-match-coverage",
           "issue_description": "The license detection is inconclusive with high confidence, because only a small part of the rule text is matched.",
@@ -86,59 +139,56 @@
             "classification_id": "notice-single-key-notice",
             "classification_description": "A notice with a single license.",
             "analysis_confidence": "high",
-            "is_license_intro": false,
             "is_license_text": false,
             "is_license_notice": true,
             "is_license_tag": false,
             "is_license_reference": false,
+            "is_license_intro": false,
             "is_suggested_matched_text_complete": true
           },
           "suggested_license": {
-            "license_expression": "gpl-3.0-plus WITH tex-exception",
-            "matched_text": "# Published under the GNU General Public License V.2, see file COPYING"
+            "license_expression": "gpl-2.0-plus",
+            "matched_text": " * This code is distributed under the terms of GNU GPL v2"
           },
           "original_licenses": [
             {
-              "score": 13.21,
-              "start_line": 4,
-              "end_line": 4,
-              "rule_identifier": "gpl-3.0-plus_with_tex-exception_4.RULE",
-              "license_expression": "gpl-3.0-plus WITH tex-exception",
+              "license_expression": "gpl-2.0-plus",
+              "score": 23.53,
+              "start_line": 8,
+              "end_line": 8,
+              "rule_identifier": "gpl-2.0-plus_180.RULE",
               "is_license_text": false,
               "is_license_notice": true,
               "is_license_reference": false,
               "is_license_tag": false,
               "is_license_intro": false,
               "matcher": "3-seq",
-              "rule_length": 53,
-              "matched_length": 7,
-              "match_coverage": 13.21,
+              "matched_length": 8,
+              "rule_length": 34,
+              "match_coverage": 23.53,
               "rule_relevance": 100,
-              "matched_text": "# Published under the GNU General Public License V.2, see file COPYING"
+              "matched_text": " * This code is distributed under the terms of GNU GPL v2"
             },
             {
-              "score": 100.0,
-              "start_line": 4,
-              "end_line": 4,
-              "rule_identifier": "gpl-2.0_756.RULE",
               "license_expression": "gpl-2.0",
+              "score": 90.0,
+              "start_line": 8,
+              "end_line": 8,
+              "rule_identifier": "gpl-2.0_223.RULE",
               "is_license_text": false,
-              "is_license_notice": false,
-              "is_license_reference": true,
+              "is_license_notice": true,
+              "is_license_reference": false,
               "is_license_tag": false,
               "is_license_intro": false,
               "matcher": "2-aho",
-              "rule_length": 6,
-              "matched_length": 6,
+              "matched_length": 3,
+              "rule_length": 3,
               "match_coverage": 100.0,
-              "rule_relevance": 100.0,
-              "matched_text": "# Published under the GNU General Public License V.2, see file COPYING"
+              "rule_relevance": 90.0,
+              "matched_text": " * This code is distributed under the terms of GNU GPL v2"
             }
           ]
-        }
-      },
-      {
-        "unique_identifier": 2,
+        },
         "files": [
           {
             "path": "issues-files/iptables1.4.10-ip6tables-restore.c",
@@ -150,64 +200,7 @@
             "start_line": 6,
             "end_line": 6
           }
-        ],
-        "license_detection_issue": {
-          "issue_category": "imperfect-match-coverage",
-          "issue_description": "The license detection is inconclusive with high confidence, because only a small part of the rule text is matched.",
-          "issue_type": {
-            "classification_id": "notice-single-key-notice",
-            "classification_description": "A notice with a single license.",
-            "analysis_confidence": "high",
-            "is_license_intro": false,
-            "is_license_text": false,
-            "is_license_notice": true,
-            "is_license_tag": false,
-            "is_license_reference": false,
-            "is_suggested_matched_text_complete": true
-          },
-          "suggested_license": {
-            "license_expression": "gpl-2.0-plus",
-            "matched_text": " * This code is distributed under the terms of GNU GPL v2"
-          },
-          "original_licenses": [
-            {
-              "score": 23.53,
-              "start_line": 8,
-              "end_line": 8,
-              "rule_identifier": "gpl-2.0-plus_180.RULE",
-              "license_expression": "gpl-2.0-plus",
-              "is_license_text": false,
-              "is_license_notice": true,
-              "is_license_reference": false,
-              "is_license_tag": false,
-              "is_license_intro": false,
-              "matcher": "3-seq",
-              "rule_length": 34,
-              "matched_length": 8,
-              "match_coverage": 23.53,
-              "rule_relevance": 100,
-              "matched_text": " * This code is distributed under the terms of GNU GPL v2"
-            },
-            {
-              "score": 90.0,
-              "start_line": 8,
-              "end_line": 8,
-              "rule_identifier": "gpl-2.0_223.RULE",
-              "license_expression": "gpl-2.0",
-              "is_license_text": false,
-              "is_license_notice": true,
-              "is_license_reference": false,
-              "is_license_tag": false,
-              "is_license_intro": false,
-              "matcher": "2-aho",
-              "rule_length": 3,
-              "matched_length": 3,
-              "match_coverage": 100.0,
-              "rule_relevance": 90.0,
-              "matched_text": " * This code is distributed under the terms of GNU GPL v2"
-            }
-          ]
-        }
+        ]
       }
     ]
   },
@@ -245,6 +238,348 @@
       "files_count": 5,
       "dirs_count": 0,
       "size_count": 44088,
+      "scan_errors": []
+    },
+    {
+      "path": "issues-files/iptables1.4.10-ip6tables-restore.c",
+      "type": "file",
+      "name": "ip6tables-restore.c",
+      "base_name": "ip6tables-restore",
+      "extension": ".c",
+      "size": 10879,
+      "date": "2010-10-29",
+      "sha1": "5f2a5ebe3ff3c8f6ed69fd423a747dd0442a6ea7",
+      "md5": "a2e1a2e51b6b8fab02759cec023f4062",
+      "sha256": null,
+      "mime_type": "text/x-c",
+      "file_type": "C source, ASCII text",
+      "programming_language": "C++",
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": true,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "gpl-2.0-plus",
+          "score": 23.53,
+          "name": "GNU General Public License 2.0 or later",
+          "short_name": "GPL 2.0 or later",
+          "category": "Copyleft",
+          "is_exception": false,
+          "owner": "Free Software Foundation (FSF)",
+          "homepage_url": "http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
+          "text_url": "http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:gpl-2.0-plus",
+          "spdx_license_key": "GPL-2.0-or-later",
+          "spdx_url": "https://spdx.org/licenses/GPL-2.0-or-later",
+          "start_line": 8,
+          "end_line": 8,
+          "matched_rule": {
+            "identifier": "gpl-2.0-plus_180.RULE",
+            "license_expression": "gpl-2.0-plus",
+            "licenses": [
+              "gpl-2.0-plus"
+            ],
+            "is_license_text": false,
+            "is_license_notice": true,
+            "is_license_reference": false,
+            "is_license_tag": false,
+            "is_license_intro": false,
+            "matcher": "3-seq",
+            "rule_length": 34,
+            "matched_length": 8,
+            "match_coverage": 23.53,
+            "rule_relevance": 100
+          },
+          "matched_text": " * This code is distributed under the terms of GNU GPL v2"
+        },
+        {
+          "key": "gpl-2.0",
+          "score": 90.0,
+          "name": "GNU General Public License 2.0",
+          "short_name": "GPL 2.0",
+          "category": "Copyleft",
+          "is_exception": false,
+          "owner": "Free Software Foundation (FSF)",
+          "homepage_url": "http://www.gnu.org/licenses/gpl-2.0.html",
+          "text_url": "http://www.gnu.org/licenses/gpl-2.0.txt",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:gpl-2.0",
+          "spdx_license_key": "GPL-2.0-only",
+          "spdx_url": "https://spdx.org/licenses/GPL-2.0-only",
+          "start_line": 8,
+          "end_line": 8,
+          "matched_rule": {
+            "identifier": "gpl-2.0_223.RULE",
+            "license_expression": "gpl-2.0",
+            "licenses": [
+              "gpl-2.0"
+            ],
+            "is_license_text": false,
+            "is_license_notice": true,
+            "is_license_reference": false,
+            "is_license_tag": false,
+            "is_license_intro": false,
+            "matcher": "2-aho",
+            "rule_length": 3,
+            "matched_length": 3,
+            "match_coverage": 100.0,
+            "rule_relevance": 90.0
+          },
+          "matched_text": " * This code is distributed under the terms of GNU GPL v2"
+        }
+      ],
+      "license_expressions": [
+        "gpl-2.0-plus",
+        "gpl-2.0"
+      ],
+      "percentage_of_license_text": null,
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "is_key_file": false,
+      "is_license_text": false,
+      "license_detection_issues": [
+        {
+          "issue_category": "imperfect-match-coverage",
+          "issue_description": "The license detection is inconclusive with high confidence, because only a small part of the rule text is matched.",
+          "issue_type": {
+            "classification_id": "notice-single-key-notice",
+            "classification_description": "A notice with a single license.",
+            "analysis_confidence": "high",
+            "is_license_text": false,
+            "is_license_notice": true,
+            "is_license_tag": false,
+            "is_license_reference": false,
+            "is_license_intro": false,
+            "is_suggested_matched_text_complete": true
+          },
+          "suggested_license": {
+            "license_expression": "gpl-2.0-plus",
+            "matched_text": " * This code is distributed under the terms of GNU GPL v2"
+          },
+          "original_licenses": [
+            {
+              "license_expression": "gpl-2.0-plus",
+              "score": 23.53,
+              "start_line": 8,
+              "end_line": 8,
+              "rule_identifier": "gpl-2.0-plus_180.RULE",
+              "is_license_text": false,
+              "is_license_notice": true,
+              "is_license_reference": false,
+              "is_license_tag": false,
+              "is_license_intro": false,
+              "matcher": "3-seq",
+              "matched_length": 8,
+              "rule_length": 34,
+              "match_coverage": 23.53,
+              "rule_relevance": 100,
+              "matched_text": " * This code is distributed under the terms of GNU GPL v2"
+            },
+            {
+              "license_expression": "gpl-2.0",
+              "score": 90.0,
+              "start_line": 8,
+              "end_line": 8,
+              "rule_identifier": "gpl-2.0_223.RULE",
+              "is_license_text": false,
+              "is_license_notice": true,
+              "is_license_reference": false,
+              "is_license_tag": false,
+              "is_license_intro": false,
+              "matcher": "2-aho",
+              "matched_length": 3,
+              "rule_length": 3,
+              "match_coverage": 100.0,
+              "rule_relevance": 90.0,
+              "matched_text": " * This code is distributed under the terms of GNU GPL v2"
+            }
+          ],
+          "file_regions": [
+            {
+              "start_line": 8,
+              "end_line": 8
+            }
+          ]
+        }
+      ],
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "issues-files/iptables1.4.10-iptables-xml.c",
+      "type": "file",
+      "name": "iptables-xml.c",
+      "base_name": "iptables-xml",
+      "extension": ".c",
+      "size": 20302,
+      "date": "2010-10-29",
+      "sha1": "6c574556090271b9802c6e10ee1163fbf157bcb5",
+      "md5": "266a65603e63fb1678e926f6adf48d64",
+      "sha256": null,
+      "mime_type": "text/x-c",
+      "file_type": "C source, ASCII text",
+      "programming_language": "C++",
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": true,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "gpl-2.0-plus",
+          "score": 23.53,
+          "name": "GNU General Public License 2.0 or later",
+          "short_name": "GPL 2.0 or later",
+          "category": "Copyleft",
+          "is_exception": false,
+          "owner": "Free Software Foundation (FSF)",
+          "homepage_url": "http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
+          "text_url": "http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:gpl-2.0-plus",
+          "spdx_license_key": "GPL-2.0-or-later",
+          "spdx_url": "https://spdx.org/licenses/GPL-2.0-or-later",
+          "start_line": 6,
+          "end_line": 6,
+          "matched_rule": {
+            "identifier": "gpl-2.0-plus_180.RULE",
+            "license_expression": "gpl-2.0-plus",
+            "licenses": [
+              "gpl-2.0-plus"
+            ],
+            "is_license_text": false,
+            "is_license_notice": true,
+            "is_license_reference": false,
+            "is_license_tag": false,
+            "is_license_intro": false,
+            "matcher": "3-seq",
+            "rule_length": 34,
+            "matched_length": 8,
+            "match_coverage": 23.53,
+            "rule_relevance": 100
+          },
+          "matched_text": " * This code is distributed under the terms of GNU GPL v2"
+        },
+        {
+          "key": "gpl-2.0",
+          "score": 90.0,
+          "name": "GNU General Public License 2.0",
+          "short_name": "GPL 2.0",
+          "category": "Copyleft",
+          "is_exception": false,
+          "owner": "Free Software Foundation (FSF)",
+          "homepage_url": "http://www.gnu.org/licenses/gpl-2.0.html",
+          "text_url": "http://www.gnu.org/licenses/gpl-2.0.txt",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:gpl-2.0",
+          "spdx_license_key": "GPL-2.0-only",
+          "spdx_url": "https://spdx.org/licenses/GPL-2.0-only",
+          "start_line": 6,
+          "end_line": 6,
+          "matched_rule": {
+            "identifier": "gpl-2.0_223.RULE",
+            "license_expression": "gpl-2.0",
+            "licenses": [
+              "gpl-2.0"
+            ],
+            "is_license_text": false,
+            "is_license_notice": true,
+            "is_license_reference": false,
+            "is_license_tag": false,
+            "is_license_intro": false,
+            "matcher": "2-aho",
+            "rule_length": 3,
+            "matched_length": 3,
+            "match_coverage": 100.0,
+            "rule_relevance": 90.0
+          },
+          "matched_text": " * This code is distributed under the terms of GNU GPL v2"
+        }
+      ],
+      "license_expressions": [
+        "gpl-2.0-plus",
+        "gpl-2.0"
+      ],
+      "percentage_of_license_text": null,
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "is_key_file": false,
+      "is_license_text": false,
+      "license_detection_issues": [
+        {
+          "issue_category": "imperfect-match-coverage",
+          "issue_description": "The license detection is inconclusive with high confidence, because only a small part of the rule text is matched.",
+          "issue_type": {
+            "classification_id": "notice-single-key-notice",
+            "classification_description": "A notice with a single license.",
+            "analysis_confidence": "high",
+            "is_license_text": false,
+            "is_license_notice": true,
+            "is_license_tag": false,
+            "is_license_reference": false,
+            "is_license_intro": false,
+            "is_suggested_matched_text_complete": true
+          },
+          "suggested_license": {
+            "license_expression": "gpl-2.0-plus",
+            "matched_text": " * This code is distributed under the terms of GNU GPL v2"
+          },
+          "original_licenses": [
+            {
+              "license_expression": "gpl-2.0-plus",
+              "score": 23.53,
+              "start_line": 6,
+              "end_line": 6,
+              "rule_identifier": "gpl-2.0-plus_180.RULE",
+              "is_license_text": false,
+              "is_license_notice": true,
+              "is_license_reference": false,
+              "is_license_tag": false,
+              "is_license_intro": false,
+              "matcher": "3-seq",
+              "matched_length": 8,
+              "rule_length": 34,
+              "match_coverage": 23.53,
+              "rule_relevance": 100,
+              "matched_text": " * This code is distributed under the terms of GNU GPL v2"
+            },
+            {
+              "license_expression": "gpl-2.0",
+              "score": 90.0,
+              "start_line": 6,
+              "end_line": 6,
+              "rule_identifier": "gpl-2.0_223.RULE",
+              "is_license_text": false,
+              "is_license_notice": true,
+              "is_license_reference": false,
+              "is_license_tag": false,
+              "is_license_intro": false,
+              "matcher": "2-aho",
+              "matched_length": 3,
+              "rule_length": 3,
+              "match_coverage": 100.0,
+              "rule_relevance": 90.0,
+              "matched_text": " * This code is distributed under the terms of GNU GPL v2"
+            }
+          ],
+          "file_regions": [
+            {
+              "start_line": 6,
+              "end_line": 6
+            }
+          ]
+        }
+      ],
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
       "scan_errors": []
     },
     {
@@ -386,23 +721,17 @@
       "is_license_text": false,
       "license_detection_issues": [
         {
-          "file_regions": [
-            {
-              "start_line": 4,
-              "end_line": 4
-            }
-          ],
           "issue_category": "imperfect-match-coverage",
           "issue_description": "The license detection is inconclusive with high confidence, because only a small part of the rule text is matched.",
           "issue_type": {
             "classification_id": "notice-single-key-notice",
             "classification_description": "A notice with a single license.",
             "analysis_confidence": "high",
-            "is_license_intro": false,
             "is_license_text": false,
             "is_license_notice": true,
             "is_license_tag": false,
             "is_license_reference": false,
+            "is_license_intro": false,
             "is_suggested_matched_text_complete": true
           },
           "suggested_license": {
@@ -411,382 +740,46 @@
           },
           "original_licenses": [
             {
+              "license_expression": "gpl-3.0-plus WITH tex-exception",
               "score": 13.21,
               "start_line": 4,
               "end_line": 4,
               "rule_identifier": "gpl-3.0-plus_with_tex-exception_4.RULE",
-              "license_expression": "gpl-3.0-plus WITH tex-exception",
               "is_license_text": false,
               "is_license_notice": true,
               "is_license_reference": false,
               "is_license_tag": false,
               "is_license_intro": false,
               "matcher": "3-seq",
-              "rule_length": 53,
               "matched_length": 7,
+              "rule_length": 53,
               "match_coverage": 13.21,
               "rule_relevance": 100,
               "matched_text": "# Published under the GNU General Public License V.2, see file COPYING"
             },
             {
+              "license_expression": "gpl-2.0",
               "score": 100.0,
               "start_line": 4,
               "end_line": 4,
               "rule_identifier": "gpl-2.0_756.RULE",
-              "license_expression": "gpl-2.0",
               "is_license_text": false,
               "is_license_notice": false,
               "is_license_reference": true,
               "is_license_tag": false,
               "is_license_intro": false,
               "matcher": "2-aho",
-              "rule_length": 6,
               "matched_length": 6,
+              "rule_length": 6,
               "match_coverage": 100.0,
               "rule_relevance": 100.0,
               "matched_text": "# Published under the GNU General Public License V.2, see file COPYING"
             }
-          ]
-        }
-      ],
-      "files_count": 0,
-      "dirs_count": 0,
-      "size_count": 0,
-      "scan_errors": []
-    },
-    {
-      "path": "issues-files/iptables1.4.10-ip6tables-restore.c",
-      "type": "file",
-      "name": "ip6tables-restore.c",
-      "base_name": "ip6tables-restore",
-      "extension": ".c",
-      "size": 10879,
-      "date": "2010-10-29",
-      "sha1": "5f2a5ebe3ff3c8f6ed69fd423a747dd0442a6ea7",
-      "md5": "a2e1a2e51b6b8fab02759cec023f4062",
-      "sha256": null,
-      "mime_type": "text/x-c",
-      "file_type": "C source, ASCII text",
-      "programming_language": "C++",
-      "is_binary": false,
-      "is_text": true,
-      "is_archive": false,
-      "is_media": false,
-      "is_source": true,
-      "is_script": false,
-      "licenses": [
-        {
-          "key": "gpl-2.0-plus",
-          "score": 23.53,
-          "name": "GNU General Public License 2.0 or later",
-          "short_name": "GPL 2.0 or later",
-          "category": "Copyleft",
-          "is_exception": false,
-          "owner": "Free Software Foundation (FSF)",
-          "homepage_url": "http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
-          "text_url": "http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
-          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:gpl-2.0-plus",
-          "spdx_license_key": "GPL-2.0-or-later",
-          "spdx_url": "https://spdx.org/licenses/GPL-2.0-or-later",
-          "start_line": 8,
-          "end_line": 8,
-          "matched_rule": {
-            "identifier": "gpl-2.0-plus_180.RULE",
-            "license_expression": "gpl-2.0-plus",
-            "licenses": [
-              "gpl-2.0-plus"
-            ],
-            "is_license_text": false,
-            "is_license_notice": true,
-            "is_license_reference": false,
-            "is_license_tag": false,
-            "is_license_intro": false,
-            "matcher": "3-seq",
-            "rule_length": 34,
-            "matched_length": 8,
-            "match_coverage": 23.53,
-            "rule_relevance": 100
-          },
-          "matched_text": " * This code is distributed under the terms of GNU GPL v2"
-        },
-        {
-          "key": "gpl-2.0",
-          "score": 90.0,
-          "name": "GNU General Public License 2.0",
-          "short_name": "GPL 2.0",
-          "category": "Copyleft",
-          "is_exception": false,
-          "owner": "Free Software Foundation (FSF)",
-          "homepage_url": "http://www.gnu.org/licenses/gpl-2.0.html",
-          "text_url": "http://www.gnu.org/licenses/gpl-2.0.txt",
-          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:gpl-2.0",
-          "spdx_license_key": "GPL-2.0-only",
-          "spdx_url": "https://spdx.org/licenses/GPL-2.0-only",
-          "start_line": 8,
-          "end_line": 8,
-          "matched_rule": {
-            "identifier": "gpl-2.0_223.RULE",
-            "license_expression": "gpl-2.0",
-            "licenses": [
-              "gpl-2.0"
-            ],
-            "is_license_text": false,
-            "is_license_notice": true,
-            "is_license_reference": false,
-            "is_license_tag": false,
-            "is_license_intro": false,
-            "matcher": "2-aho",
-            "rule_length": 3,
-            "matched_length": 3,
-            "match_coverage": 100.0,
-            "rule_relevance": 90.0
-          },
-          "matched_text": " * This code is distributed under the terms of GNU GPL v2"
-        }
-      ],
-      "license_expressions": [
-        "gpl-2.0-plus",
-        "gpl-2.0"
-      ],
-      "percentage_of_license_text": null,
-      "is_legal": false,
-      "is_manifest": false,
-      "is_readme": false,
-      "is_top_level": false,
-      "is_key_file": false,
-      "is_license_text": false,
-      "license_detection_issues": [
-        {
+          ],
           "file_regions": [
             {
-              "start_line": 8,
-              "end_line": 8
-            }
-          ],
-          "issue_category": "imperfect-match-coverage",
-          "issue_description": "The license detection is inconclusive with high confidence, because only a small part of the rule text is matched.",
-          "issue_type": {
-            "classification_id": "notice-single-key-notice",
-            "classification_description": "A notice with a single license.",
-            "analysis_confidence": "high",
-            "is_license_intro": false,
-            "is_license_text": false,
-            "is_license_notice": true,
-            "is_license_tag": false,
-            "is_license_reference": false,
-            "is_suggested_matched_text_complete": true
-          },
-          "suggested_license": {
-            "license_expression": "gpl-2.0-plus",
-            "matched_text": " * This code is distributed under the terms of GNU GPL v2"
-          },
-          "original_licenses": [
-            {
-              "score": 23.53,
-              "start_line": 8,
-              "end_line": 8,
-              "rule_identifier": "gpl-2.0-plus_180.RULE",
-              "license_expression": "gpl-2.0-plus",
-              "is_license_text": false,
-              "is_license_notice": true,
-              "is_license_reference": false,
-              "is_license_tag": false,
-              "is_license_intro": false,
-              "matcher": "3-seq",
-              "rule_length": 34,
-              "matched_length": 8,
-              "match_coverage": 23.53,
-              "rule_relevance": 100,
-              "matched_text": " * This code is distributed under the terms of GNU GPL v2"
-            },
-            {
-              "score": 90.0,
-              "start_line": 8,
-              "end_line": 8,
-              "rule_identifier": "gpl-2.0_223.RULE",
-              "license_expression": "gpl-2.0",
-              "is_license_text": false,
-              "is_license_notice": true,
-              "is_license_reference": false,
-              "is_license_tag": false,
-              "is_license_intro": false,
-              "matcher": "2-aho",
-              "rule_length": 3,
-              "matched_length": 3,
-              "match_coverage": 100.0,
-              "rule_relevance": 90.0,
-              "matched_text": " * This code is distributed under the terms of GNU GPL v2"
-            }
-          ]
-        }
-      ],
-      "files_count": 0,
-      "dirs_count": 0,
-      "size_count": 0,
-      "scan_errors": []
-    },
-    {
-      "path": "issues-files/iptables1.4.10-iptables-xml.c",
-      "type": "file",
-      "name": "iptables-xml.c",
-      "base_name": "iptables-xml",
-      "extension": ".c",
-      "size": 20302,
-      "date": "2010-10-29",
-      "sha1": "6c574556090271b9802c6e10ee1163fbf157bcb5",
-      "md5": "266a65603e63fb1678e926f6adf48d64",
-      "sha256": null,
-      "mime_type": "text/x-c",
-      "file_type": "C source, ASCII text",
-      "programming_language": "C++",
-      "is_binary": false,
-      "is_text": true,
-      "is_archive": false,
-      "is_media": false,
-      "is_source": true,
-      "is_script": false,
-      "licenses": [
-        {
-          "key": "gpl-2.0-plus",
-          "score": 23.53,
-          "name": "GNU General Public License 2.0 or later",
-          "short_name": "GPL 2.0 or later",
-          "category": "Copyleft",
-          "is_exception": false,
-          "owner": "Free Software Foundation (FSF)",
-          "homepage_url": "http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
-          "text_url": "http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
-          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:gpl-2.0-plus",
-          "spdx_license_key": "GPL-2.0-or-later",
-          "spdx_url": "https://spdx.org/licenses/GPL-2.0-or-later",
-          "start_line": 6,
-          "end_line": 6,
-          "matched_rule": {
-            "identifier": "gpl-2.0-plus_180.RULE",
-            "license_expression": "gpl-2.0-plus",
-            "licenses": [
-              "gpl-2.0-plus"
-            ],
-            "is_license_text": false,
-            "is_license_notice": true,
-            "is_license_reference": false,
-            "is_license_tag": false,
-            "is_license_intro": false,
-            "matcher": "3-seq",
-            "rule_length": 34,
-            "matched_length": 8,
-            "match_coverage": 23.53,
-            "rule_relevance": 100
-          },
-          "matched_text": " * This code is distributed under the terms of GNU GPL v2"
-        },
-        {
-          "key": "gpl-2.0",
-          "score": 90.0,
-          "name": "GNU General Public License 2.0",
-          "short_name": "GPL 2.0",
-          "category": "Copyleft",
-          "is_exception": false,
-          "owner": "Free Software Foundation (FSF)",
-          "homepage_url": "http://www.gnu.org/licenses/gpl-2.0.html",
-          "text_url": "http://www.gnu.org/licenses/gpl-2.0.txt",
-          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:gpl-2.0",
-          "spdx_license_key": "GPL-2.0-only",
-          "spdx_url": "https://spdx.org/licenses/GPL-2.0-only",
-          "start_line": 6,
-          "end_line": 6,
-          "matched_rule": {
-            "identifier": "gpl-2.0_223.RULE",
-            "license_expression": "gpl-2.0",
-            "licenses": [
-              "gpl-2.0"
-            ],
-            "is_license_text": false,
-            "is_license_notice": true,
-            "is_license_reference": false,
-            "is_license_tag": false,
-            "is_license_intro": false,
-            "matcher": "2-aho",
-            "rule_length": 3,
-            "matched_length": 3,
-            "match_coverage": 100.0,
-            "rule_relevance": 90.0
-          },
-          "matched_text": " * This code is distributed under the terms of GNU GPL v2"
-        }
-      ],
-      "license_expressions": [
-        "gpl-2.0-plus",
-        "gpl-2.0"
-      ],
-      "percentage_of_license_text": null,
-      "is_legal": false,
-      "is_manifest": false,
-      "is_readme": false,
-      "is_top_level": false,
-      "is_key_file": false,
-      "is_license_text": false,
-      "license_detection_issues": [
-        {
-          "file_regions": [
-            {
-              "start_line": 6,
-              "end_line": 6
-            }
-          ],
-          "issue_category": "imperfect-match-coverage",
-          "issue_description": "The license detection is inconclusive with high confidence, because only a small part of the rule text is matched.",
-          "issue_type": {
-            "classification_id": "notice-single-key-notice",
-            "classification_description": "A notice with a single license.",
-            "analysis_confidence": "high",
-            "is_license_intro": false,
-            "is_license_text": false,
-            "is_license_notice": true,
-            "is_license_tag": false,
-            "is_license_reference": false,
-            "is_suggested_matched_text_complete": true
-          },
-          "suggested_license": {
-            "license_expression": "gpl-2.0-plus",
-            "matched_text": " * This code is distributed under the terms of GNU GPL v2"
-          },
-          "original_licenses": [
-            {
-              "score": 23.53,
-              "start_line": 6,
-              "end_line": 6,
-              "rule_identifier": "gpl-2.0-plus_180.RULE",
-              "license_expression": "gpl-2.0-plus",
-              "is_license_text": false,
-              "is_license_notice": true,
-              "is_license_reference": false,
-              "is_license_tag": false,
-              "is_license_intro": false,
-              "matcher": "3-seq",
-              "rule_length": 34,
-              "matched_length": 8,
-              "match_coverage": 23.53,
-              "rule_relevance": 100,
-              "matched_text": " * This code is distributed under the terms of GNU GPL v2"
-            },
-            {
-              "score": 90.0,
-              "start_line": 6,
-              "end_line": 6,
-              "rule_identifier": "gpl-2.0_223.RULE",
-              "license_expression": "gpl-2.0",
-              "is_license_text": false,
-              "is_license_notice": true,
-              "is_license_reference": false,
-              "is_license_tag": false,
-              "is_license_intro": false,
-              "matcher": "2-aho",
-              "rule_length": 3,
-              "matched_length": 3,
-              "match_coverage": 100.0,
-              "rule_relevance": 90.0,
-              "matched_text": " * This code is distributed under the terms of GNU GPL v2"
+              "start_line": 4,
+              "end_line": 4
             }
           ]
         }
@@ -935,23 +928,17 @@
       "is_license_text": false,
       "license_detection_issues": [
         {
-          "file_regions": [
-            {
-              "start_line": 3,
-              "end_line": 3
-            }
-          ],
           "issue_category": "imperfect-match-coverage",
           "issue_description": "The license detection is inconclusive with high confidence, because only a small part of the rule text is matched.",
           "issue_type": {
             "classification_id": "notice-single-key-notice",
             "classification_description": "A notice with a single license.",
             "analysis_confidence": "high",
-            "is_license_intro": false,
             "is_license_text": false,
             "is_license_notice": true,
             "is_license_tag": false,
             "is_license_reference": false,
+            "is_license_intro": false,
             "is_suggested_matched_text_complete": true
           },
           "suggested_license": {
@@ -960,40 +947,46 @@
           },
           "original_licenses": [
             {
+              "license_expression": "gpl-3.0-plus WITH tex-exception",
               "score": 13.21,
               "start_line": 3,
               "end_line": 3,
               "rule_identifier": "gpl-3.0-plus_with_tex-exception_4.RULE",
-              "license_expression": "gpl-3.0-plus WITH tex-exception",
               "is_license_text": false,
               "is_license_notice": true,
               "is_license_reference": false,
               "is_license_tag": false,
               "is_license_intro": false,
               "matcher": "3-seq",
-              "rule_length": 53,
               "matched_length": 7,
+              "rule_length": 53,
               "match_coverage": 13.21,
               "rule_relevance": 100,
               "matched_text": "/* Published under the GNU General Public License V.2, see file COPYING */"
             },
             {
+              "license_expression": "gpl-2.0",
               "score": 100.0,
               "start_line": 3,
               "end_line": 3,
               "rule_identifier": "gpl-2.0_756.RULE",
-              "license_expression": "gpl-2.0",
               "is_license_text": false,
               "is_license_notice": false,
               "is_license_reference": true,
               "is_license_tag": false,
               "is_license_intro": false,
               "matcher": "2-aho",
-              "rule_length": 6,
               "matched_length": 6,
+              "rule_length": 6,
               "match_coverage": 100.0,
               "rule_relevance": 100.0,
               "matched_text": "/* Published under the GNU General Public License V.2, see file COPYING */"
+            }
+          ],
+          "file_regions": [
+            {
+              "start_line": 3,
+              "end_line": 3
             }
           ]
         }
@@ -1142,23 +1135,17 @@
       "is_license_text": false,
       "license_detection_issues": [
         {
-          "file_regions": [
-            {
-              "start_line": 3,
-              "end_line": 3
-            }
-          ],
           "issue_category": "imperfect-match-coverage",
           "issue_description": "The license detection is inconclusive with high confidence, because only a small part of the rule text is matched.",
           "issue_type": {
             "classification_id": "notice-single-key-notice",
             "classification_description": "A notice with a single license.",
             "analysis_confidence": "high",
-            "is_license_intro": false,
             "is_license_text": false,
             "is_license_notice": true,
             "is_license_tag": false,
             "is_license_reference": false,
+            "is_license_intro": false,
             "is_suggested_matched_text_complete": true
           },
           "suggested_license": {
@@ -1167,40 +1154,46 @@
           },
           "original_licenses": [
             {
+              "license_expression": "gpl-3.0-plus WITH tex-exception",
               "score": 13.21,
               "start_line": 3,
               "end_line": 3,
               "rule_identifier": "gpl-3.0-plus_with_tex-exception_4.RULE",
-              "license_expression": "gpl-3.0-plus WITH tex-exception",
               "is_license_text": false,
               "is_license_notice": true,
               "is_license_reference": false,
               "is_license_tag": false,
               "is_license_intro": false,
               "matcher": "3-seq",
-              "rule_length": 53,
               "matched_length": 7,
+              "rule_length": 53,
               "match_coverage": 13.21,
               "rule_relevance": 100,
               "matched_text": "/* Published under the GNU General Public License V.2, see file COPYING */"
             },
             {
+              "license_expression": "gpl-2.0",
               "score": 100.0,
               "start_line": 3,
               "end_line": 3,
               "rule_identifier": "gpl-2.0_756.RULE",
-              "license_expression": "gpl-2.0",
               "is_license_text": false,
               "is_license_notice": false,
               "is_license_reference": true,
               "is_license_tag": false,
               "is_license_intro": false,
               "matcher": "2-aho",
-              "rule_length": 6,
               "matched_length": 6,
+              "rule_length": 6,
               "match_coverage": 100.0,
               "rule_relevance": 100.0,
               "matched_text": "/* Published under the GNU General Public License V.2, see file COPYING */"
+            }
+          ],
+          "file_regions": [
+            {
+              "start_line": 3,
+              "end_line": 3
             }
           ]
         }

--- a/tests/test_analyzer_plugin.py
+++ b/tests/test_analyzer_plugin.py
@@ -54,6 +54,7 @@ class TestAnalyzerPlugin(FileBasedTesting):
             self.get_test_loc("results_analyzer_expected.json"),
             result_file,
             remove_file_date=True,
+            regen=False,
         )
 
     def test_analyze_results_plugin_load_from_json_analyze(self):
@@ -71,6 +72,7 @@ class TestAnalyzerPlugin(FileBasedTesting):
         check_json_scan(
             self.get_test_loc("results_analyzer_from_sample_json_expected.json"),
             result_file,
+            regen=False,
         )
 
     @staticmethod

--- a/tests/test_analyzer_summary.py
+++ b/tests/test_analyzer_summary.py
@@ -50,6 +50,7 @@ class TestAnalyzerPluginSummary(FileBasedTesting):
                 "results_analyzer_from_sample_json_expected_summary.json"
             ),
             result_file,
+            regen=False,
         )
 
 


### PR DESCRIPTION
- Adds script to use analyzer on debian copyrights 
- Adds function to convert licensedcode.match.LicenseMatch objects to
scancode_analyzer.analyzer_plugin.LicenseMatch objects, and fix
a bug in summary.
- Regens test expectations